### PR TITLE
add system version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ A Prometheus exporter for VergeOS that collects metrics about VSAN tiers, cluste
 
 Prebuilt binaries for Linux, Windows, and macOS (both amd64 and arm64) are available on the [Releases](https://github.com/verge-io/vergeos-exporter/releases) page.
 
+Note that the version number is included in the filename (e.g., vergeos-exporter_1.1.6_Darwin_x86_64.tar.gz), so ensure you download the correct version for your system.
+
 1. Download the appropriate binary for your system
 2. Extract the archive:
    ```bash

--- a/collectors/base.go
+++ b/collectors/base.go
@@ -65,12 +65,11 @@ func (bc *BaseCollector) getSystemName() (string, error) {
 	}
 	defer resp.Body.Close()
 
-	// Read and log the response body
+	// Read the response body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response body: %v", err)
 	}
-	fmt.Printf("Base collector settings API response: %s\n", string(bodyBytes))
 
 	// Create a new reader with the same bytes for JSON decoding
 	var systemNameResp []struct {

--- a/collectors/system.go
+++ b/collectors/system.go
@@ -1,0 +1,150 @@
+package collectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// UpdatePackage represents a package in the update_dashboard response
+type UpdatePackage struct {
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	Version        string `json:"version"`
+	Branch         string `json:"branch"`
+	SourcePackages []struct {
+		Key        int           `json:"$key"`
+		Downloaded bool          `json:"downloaded"`
+		Version    string        `json:"version"`
+		Files      []interface{} `json:"files"`
+	} `json:"source_packages"`
+}
+
+// UpdateDashboardResponse represents the API response for update_dashboard
+type UpdateDashboardResponse struct {
+	Packages []UpdatePackage `json:"packages"`
+	// Other fields like logs, branches, settings, etc. are omitted as we don't need them
+}
+
+// SystemCollector collects metrics about VergeOS system versions
+type SystemCollector struct {
+	BaseCollector
+	mutex sync.Mutex
+
+	// System info
+	systemName string
+
+	// Metrics
+	systemVersion       *prometheus.GaugeVec
+	systemVersionLatest *prometheus.GaugeVec
+	systemBranch        *prometheus.GaugeVec
+	systemInfo          *prometheus.GaugeVec
+}
+
+// NewSystemCollector creates a new SystemCollector
+func NewSystemCollector(url string, client *http.Client, username, password string) *SystemCollector {
+	sc := &SystemCollector{
+		BaseCollector: BaseCollector{
+			url:        url,
+			httpClient: client,
+		},
+		systemName: "unknown", // Will be updated in Collect
+		systemVersion: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vergeos_system_version",
+			Help: "Current version of the VergeOS system (always 1, version in label)",
+		}, []string{"system_name", "version"}),
+		systemVersionLatest: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vergeos_system_version_latest",
+			Help: "Latest available version of the VergeOS system (always 1, version in label)",
+		}, []string{"system_name", "version"}),
+		systemBranch: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vergeos_system_branch",
+			Help: "Branch of the VergeOS system (always 1, branch in label)",
+		}, []string{"system_name", "branch"}),
+		systemInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vergeos_system_info",
+			Help: "Information about the VergeOS system",
+		}, []string{"system_name", "current_version", "latest_version", "branch"}),
+	}
+
+	// Authenticate with the API
+	if err := sc.authenticate(username, password); err != nil {
+		fmt.Printf("Error authenticating with VergeOS API: %v\n", err)
+	}
+
+	return sc
+}
+
+// Describe implements prometheus.Collector
+func (sc *SystemCollector) Describe(ch chan<- *prometheus.Desc) {
+	sc.systemVersion.Describe(ch)
+	sc.systemVersionLatest.Describe(ch)
+	sc.systemBranch.Describe(ch)
+	sc.systemInfo.Describe(ch)
+}
+
+// Collect implements prometheus.Collector
+func (sc *SystemCollector) Collect(ch chan<- prometheus.Metric) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+
+	// Get system name
+	systemName, err := sc.getSystemName()
+	if err != nil {
+		fmt.Printf("Error getting system name: %v\n", err)
+		return
+	}
+	sc.systemName = systemName
+
+	// Get update dashboard data
+	req, err := sc.makeRequest("GET", "/api/v4/update_dashboard?limit=50")
+	if err != nil {
+		fmt.Printf("Error creating request: %v\n", err)
+		return
+	}
+
+	resp, err := sc.httpClient.Do(req)
+	if err != nil {
+		fmt.Printf("Error executing request: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	var dashboard UpdateDashboardResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dashboard); err != nil {
+		fmt.Printf("Error decoding response: %v\n", err)
+		return
+	}
+
+	// Find the ybos package
+	for _, pkg := range dashboard.Packages {
+		if pkg.Name == "ybos" {
+			// Set current version as a string label
+			sc.systemVersion.WithLabelValues(sc.systemName, pkg.Version).Set(1)
+
+			// Set branch as a string label
+			sc.systemBranch.WithLabelValues(sc.systemName, pkg.Branch).Set(1)
+
+			// Get latest version from the first source package
+			latestVersion := ""
+			if len(pkg.SourcePackages) > 0 {
+				latestVersion = pkg.SourcePackages[0].Version
+				sc.systemVersionLatest.WithLabelValues(sc.systemName, latestVersion).Set(1)
+			}
+
+			// Set system info metric with all information as labels
+			sc.systemInfo.WithLabelValues(sc.systemName, pkg.Version, latestVersion, pkg.Branch).Set(1)
+
+			break
+		}
+	}
+
+	// Collect all metrics
+	sc.systemVersion.Collect(ch)
+	sc.systemVersionLatest.Collect(ch)
+	sc.systemBranch.Collect(ch)
+	sc.systemInfo.Collect(ch)
+}

--- a/main.go
+++ b/main.go
@@ -37,11 +37,13 @@ func main() {
 	storageCollector := collectors.NewStorageCollector(*vergeURL, httpClient, *vergeUsername, *vergePassword)
 	networkCollector := collectors.NewNetworkCollector(*vergeURL, httpClient, *vergeUsername, *vergePassword)
 	clusterCollector := collectors.NewClusterCollector(*vergeURL, httpClient, *vergeUsername, *vergePassword)
+	systemCollector := collectors.NewSystemCollector(*vergeURL, httpClient, *vergeUsername, *vergePassword)
 
 	prometheus.MustRegister(nodeCollector)
 	prometheus.MustRegister(storageCollector)
 	prometheus.MustRegister(networkCollector)
 	prometheus.MustRegister(clusterCollector)
+	prometheus.MustRegister(systemCollector)
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/metrics.md
+++ b/metrics.md
@@ -106,3 +106,9 @@ All drive metrics include the following labels:
 - **Used Cores in Cluster**: `vergeos_cluster_used_cores` (Gauge, labeled by `system_name` and `cluster`)
 - **Physical RAM Used (MB)**: `vergeos_cluster_phys_ram_used` (Gauge, labeled by `system_name` and `cluster`)
 
+---
+## System Version Metrics
+- **System Version**: `vergeos_system_version` (Gauge, labeled by `system_name` and `version`, always 1)
+- **Latest Available System Version**: `vergeos_system_version_latest` (Gauge, labeled by `system_name` and `version`, always 1)
+- **System Branch**: `vergeos_system_branch` (Gauge, labeled by `system_name` and `branch`, always 1)
+- **System Info**: `vergeos_system_info` (Gauge, labeled by `system_name`, `current_version`, `latest_version`, and `branch`, always 1)


### PR DESCRIPTION
fixes https://github.com/verge-io/vergeos-exporter/issues/6
adds:
## System Version Metrics
- **System Version**: `vergeos_system_version` (Gauge, labeled by `system_name` and `version`, always 1)
- **Latest Available System Version**: `vergeos_system_version_latest` (Gauge, labeled by `system_name` and `version`, always 1)
- **System Branch**: `vergeos_system_branch` (Gauge, labeled by `system_name` and `branch`, always 1)
- **System Info**: `vergeos_system_info` (Gauge, labeled by `system_name`, `current_version`, `latest_version`, and `branch`, always 1)