### PR TITLE
Corrected help label seconds to microseconds

### DIFF
--- a/collectors/storage.go
+++ b/collectors/storage.go
@@ -130,7 +130,7 @@ func NewStorageCollector(url string, client *http.Client, username, password str
 		}, driveLabels),
 		driveServiceTime: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vergeos_drive_service_time",
-			Help: "Drive service time in seconds",
+			Help: "Drive service time in milliseconds",
 		}, driveLabels),
 		vsanCapacity: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vergeos_vsan_tier_capacity",

--- a/metrics.md
+++ b/metrics.md
@@ -38,7 +38,7 @@
 - **Drive Power On Hours**: `vergeos_drive_power_on_hours` (Counter, labeled by `system_name`, `node_name`, `drive_name`, `tier`, and `serial`)
 - **Drive Reallocated Sectors**: `vergeos_drive_reallocated_sectors` (Counter, labeled by `system_name`, `node_name`, `drive_name`, `tier`, and `serial`)
 - **Drive Temperature**: `vergeos_drive_temperature` (Gauge, labeled by `system_name`, `node_name`, `drive_name`, `tier`, and `serial`)
-- **Drive Service Time**: `vergeos_drive_service_time` (Gauge, labeled by `system_name`, `node_name`, `drive_name`, `tier`, and `serial`, in seconds)
+- **Drive Service Time**: `vergeos_drive_service_time` (Gauge, labeled by `system_name`, `node_name`, `drive_name`, `tier`, and `serial`, in milliseconds)
 
 ### Drive Metrics
 All drive metrics include the following labels:


### PR DESCRIPTION
Fixes #31 

Corrected help label seconds to microseconds
