### PR TITLE
Fix docker-compose demo out-of-box experience

### DIFF
--- a/examples/docker-compose/.env
+++ b/examples/docker-compose/.env
@@ -3,8 +3,8 @@ VERGE_URL=https://your-vergeos-host
 VERGE_USERNAME=your-username
 VERGE_PASSWORD=your-password
 WEB_LISTEN=:9888
-# Skip TLS certificate verification (true for self-signed certs)
-INSECURE=true
+# Uncomment to skip TLS certificate verification (for self-signed certs)
+#INSECURE=true
 
 # Exporter build inputs (matching GitHub Releases assets)
 # Example tag: v1.1.9 -> set EXPORTER_VERSION=1.1.9

--- a/examples/docker-compose/.env
+++ b/examples/docker-compose/.env
@@ -3,6 +3,8 @@ VERGE_URL=https://your-vergeos-host
 VERGE_USERNAME=your-username
 VERGE_PASSWORD=your-password
 WEB_LISTEN=:9888
+# Skip TLS certificate verification (true for self-signed certs)
+INSECURE=true
 
 # Exporter build inputs (matching GitHub Releases assets)
 # Example tag: v1.1.9 -> set EXPORTER_VERSION=1.1.9

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -32,6 +32,7 @@ This stack deploys three interconnected services:
    VERGE_URL=https://your-vergeos-host
    VERGE_USERNAME=your-username
    VERGE_PASSWORD=your-password
+   INSECURE=true
    GRAFANA_ADMIN_PASSWORD=secure-password
    ```
 
@@ -88,6 +89,7 @@ Once running, you can access:
 | `VERGE_URL` | VergeOS instance URL | Required |
 | `VERGE_USERNAME` | VergeOS username | Required |
 | `VERGE_PASSWORD` | VergeOS password | Required |
+| `INSECURE` | Skip TLS certificate verification (self-signed certs) | `true` |
 | `EXPORTER_VERSION` | Exporter image tag | `latest` |
 | `GRAFANA_ADMIN_PASSWORD` | Grafana admin password | `admin` |
 
@@ -142,6 +144,8 @@ docker compose down
 ```bash
 docker compose down -v
 ```
+
+This removes Prometheus metrics data and Grafana settings (dashboards, passwords, etc.). Use this when configuration changes aren't taking effect or you want to start fresh.
 
 ### Restart a specific service
 

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -32,7 +32,7 @@ This stack deploys three interconnected services:
    VERGE_URL=https://your-vergeos-host
    VERGE_USERNAME=your-username
    VERGE_PASSWORD=your-password
-   INSECURE=true
+   #INSECURE=true
    GRAFANA_ADMIN_PASSWORD=secure-password
    ```
 
@@ -89,7 +89,7 @@ Once running, you can access:
 | `VERGE_URL` | VergeOS instance URL | Required |
 | `VERGE_USERNAME` | VergeOS username | Required |
 | `VERGE_PASSWORD` | VergeOS password | Required |
-| `INSECURE` | Skip TLS certificate verification (self-signed certs) | `true` |
+| `INSECURE` | Skip TLS certificate verification (self-signed certs) | `false` |
 | `EXPORTER_VERSION` | Exporter image tag | `latest` |
 | `GRAFANA_ADMIN_PASSWORD` | Grafana admin password | `admin` |
 

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/vergeos-dashboard-pinuid.json
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
@@ -46,6 +47,7 @@ services:
       - "-verge.username=${VERGE_USERNAME}"
       - "-verge.password=${VERGE_PASSWORD}"
       - "-web.listen-address=:9888"
+      - "-insecure=${INSECURE:-true}"
     ports:
       - "9888:9888"
     networks:

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - "-verge.username=${VERGE_USERNAME}"
       - "-verge.password=${VERGE_PASSWORD}"
       - "-web.listen-address=:9888"
-      - "-insecure=${INSECURE:-true}"
+      - "-insecure=${INSECURE:-false}"
     ports:
       - "9888:9888"
     networks:

--- a/examples/docker-compose/grafana/provisioning/dashboards/vergeos-dashboard-pinuid.json
+++ b/examples/docker-compose/grafana/provisioning/dashboards/vergeos-dashboard-pinuid.json
@@ -2094,8 +2094,10 @@
     "list": [
       {
         "current": {
-          "text": "fms-1",
-          "value": "fms-1"
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
         },
         "definition": "label_values(vergeos_cluster_total_nodes,system_name)",
         "label": "System",
@@ -2108,7 +2110,8 @@
         },
         "refresh": 1,
         "regex": "",
-        "type": "query"
+        "type": "query",
+        "includeAll": true
       },
       {
         "current": {
@@ -2155,7 +2158,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},

--- a/examples/docker-compose/grafana/provisioning/dashboards/vergeos-dashboard-pinuid.json
+++ b/examples/docker-compose/grafana/provisioning/dashboards/vergeos-dashboard-pinuid.json
@@ -2158,7 +2158,7 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
## Summary
- Wire up `-insecure` flag via `INSECURE` env var for self-signed certs
- Default dashboard system variable to "All" instead of hardcoded lab value
- Set time range to last 5 minutes so new installs show data immediately
- Set VergeOS dashboard as Grafana home page
- Add note about `docker compose down -v` for fresh starts

## Test plan
- [x] `docker compose down -v && docker compose up -d` with fresh `.env` values
- [x] Grafana opens directly to VergeOS dashboard
- [x] Dashboard shows data without manually selecting system variable
- [x] Exporter connects with `-insecure` flag via self-signed certs