### PR TITLE
Native Windows service support (removes NSSM dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The exporter will now start automatically on system boot and restart if it crash
 
 ## Running as a Windows Service
 
-The exporter has **built-in Windows service support** — no third-party wrapper (such as NSSM) is required. The `-service` flag registers, controls, and removes the service directly through the Windows Service Control Manager.
+The exporter has **built-in Windows service support** — no third-party wrapper is required. The `-service` flag registers, controls, and removes the service directly through the Windows Service Control Manager.
 
 1. Create a directory for the exporter and copy the executable there:
 ```powershell

--- a/README.md
+++ b/README.md
@@ -188,23 +188,27 @@ The exporter will now start automatically on system boot and restart if it crash
 
 To run the VergeOS Exporter as a Windows service, we'll use NSSM (Non-Sucking Service Manager):
 
-1. Download NSSM from the [official website](https://nssm.cc/download)
+1. Install NSSM. The easiest way is via [Chocolatey](https://community.chocolatey.org/packages/NSSM#install) (run PowerShell as Administrator):
+   ```powershell
+   choco install nssm
+   ```
+   Chocolatey adds `nssm` to your `PATH`, so the commands below work as written.
 
-2. Extract the NSSM archive and copy the appropriate executable (nssm.exe) to a permanent location:
-   - Use `nssm64.exe` for 64-bit systems (recommended)
-   - Copy it to `C:\Program Files\nssm\nssm.exe`
+   > **Note:** The historical download site `nssm.cc` is frequently unreachable. If you'd rather not use Chocolatey, download a build directly from the [NSSM GitHub mirror](https://github.com/kirillkovalenko/nssm/releases) or the [Chocolatey package files](https://community.chocolatey.org/packages/NSSM#files), extract the archive, and copy the appropriate executable to a permanent location:
+   > - Use the `win64` build for 64-bit systems (recommended)
+   > - Copy `nssm.exe` to `C:\Program Files\nssm\nssm.exe` and add that folder to your `PATH`
 
-3. Create a directory for the exporter:
+2. Create a directory for the exporter:
 ```powershell
 mkdir "C:\Program Files\vergeos-exporter"
 ```
 
-4. Copy the vergeos-exporter executable to this directory:
+3. Copy the vergeos-exporter executable to this directory:
 ```powershell
 copy vergeos-exporter.exe "C:\Program Files\vergeos-exporter"
 ```
 
-5. Install the service using NSSM (run Command Prompt as Administrator):
+4. Install the service using NSSM (run Command Prompt as Administrator):
 ```batch
 nssm install VergeOSExporter "C:\Program Files\vergeos-exporter\vergeos-exporter.exe"
 nssm set VergeOSExporter AppParameters "-verge.url=https://VERGEURL -verge.username=admin -verge.password=PASSWORD"
@@ -216,7 +220,7 @@ nssm set VergeOSExporter AppStdout "C:\Program Files\vergeos-exporter\logs\stdou
 nssm set VergeOSExporter AppStderr "C:\Program Files\vergeos-exporter\logs\stderr.log"
 ```
 
-6. Start the service:
+5. Start the service:
 ```batch
 nssm start VergeOSExporter
 ```

--- a/README.md
+++ b/README.md
@@ -188,15 +188,11 @@ The exporter will now start automatically on system boot and restart if it crash
 
 To run the VergeOS Exporter as a Windows service, we'll use NSSM (Non-Sucking Service Manager):
 
-1. Install NSSM. The easiest way is via [Chocolatey](https://community.chocolatey.org/packages/NSSM#install) (run PowerShell as Administrator):
+1. Install NSSM via [Chocolatey](https://community.chocolatey.org/packages/NSSM#install) (run PowerShell as Administrator):
    ```powershell
    choco install nssm
    ```
    Chocolatey adds `nssm` to your `PATH`, so the commands below work as written.
-
-   > **Note:** The historical download site `nssm.cc` is frequently unreachable. If you'd rather not use Chocolatey, download a build directly from the [NSSM GitHub mirror](https://github.com/kirillkovalenko/nssm/releases) or the [Chocolatey package files](https://community.chocolatey.org/packages/NSSM#files), extract the archive, and copy the appropriate executable to a permanent location:
-   > - Use the `win64` build for 64-bit systems (recommended)
-   > - Copy `nssm.exe` to `C:\Program Files\nssm\nssm.exe` and add that folder to your `PATH`
 
 2. Create a directory for the exporter:
 ```powershell

--- a/README.md
+++ b/README.md
@@ -186,53 +186,43 @@ The exporter will now start automatically on system boot and restart if it crash
 
 ## Running as a Windows Service
 
-To run the VergeOS Exporter as a Windows service, we'll use NSSM (Non-Sucking Service Manager):
+The exporter has **built-in Windows service support** — no third-party wrapper (such as NSSM) is required. The `-service` flag registers, controls, and removes the service directly through the Windows Service Control Manager.
 
-1. Install NSSM via [Chocolatey](https://community.chocolatey.org/packages/NSSM#install) (run PowerShell as Administrator):
-   ```powershell
-   choco install nssm
-   ```
-   Chocolatey adds `nssm` to your `PATH`, so the commands below work as written.
-
-2. Create a directory for the exporter:
+1. Create a directory for the exporter and copy the executable there:
 ```powershell
 mkdir "C:\Program Files\vergeos-exporter"
-```
-
-3. Copy the vergeos-exporter executable to this directory:
-```powershell
 copy vergeos-exporter.exe "C:\Program Files\vergeos-exporter"
 ```
 
-4. Install the service using NSSM (run Command Prompt as Administrator):
-```batch
-nssm install VergeOSExporter "C:\Program Files\vergeos-exporter\vergeos-exporter.exe"
-nssm set VergeOSExporter AppParameters "-verge.url=https://VERGEURL -verge.username=admin -verge.password=PASSWORD"
-nssm set VergeOSExporter DisplayName "VergeOS Exporter"
-nssm set VergeOSExporter Description "Prometheus exporter for VergeOS metrics"
-nssm set VergeOSExporter Start SERVICE_AUTO_START
-nssm set VergeOSExporter ObjectName LocalSystem
-nssm set VergeOSExporter AppStdout "C:\Program Files\vergeos-exporter\logs\stdout.log"
-nssm set VergeOSExporter AppStderr "C:\Program Files\vergeos-exporter\logs\stderr.log"
+2. Install the service (run **PowerShell or Command Prompt as Administrator**). Any exporter flags you pass here are stored and reused each time the service starts:
+```powershell
+cd "C:\Program Files\vergeos-exporter"
+.\vergeos-exporter.exe -service=install `
+  -verge.url="https://VERGEURL" `
+  -verge.username="admin" `
+  -verge.password="PASSWORD" `
+  -log.file="C:\Program Files\vergeos-exporter\logs\exporter.log"
+```
+   The service is created with automatic startup, so it will launch on boot. Use `-log.file` to capture logs, since a Windows service has no console. Credentials can also be supplied via the `VERGE_URL`, `VERGE_USERNAME`, and `VERGE_PASSWORD` environment variables instead of flags.
+
+3. Start the service:
+```powershell
+.\vergeos-exporter.exe -service=start
 ```
 
-5. Start the service:
-```batch
-nssm start VergeOSExporter
-```
-
-You can also manage the service using Windows Service Manager:
+You can also manage the service using the Windows Service Manager:
 - Open Services (services.msc)
 - Find "VergeOS Exporter" in the list
 - Right-click to Start, Stop, or Restart the service
 - View service status and modify startup type
 
-To remove the service:
-```batch
-nssm remove VergeOSExporter confirm
+To stop or remove the service:
+```powershell
+.\vergeos-exporter.exe -service=stop
+.\vergeos-exporter.exe -service=uninstall
 ```
 
-The service will now start automatically when Windows boots. Logs can be found in the specified log directory.
+The service will now start automatically when Windows boots. Logs can be found at the path given to `-log.file`.
 
 ## Running with Docker Compose demo/example
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/verge-io/govergeos v0.2.0
+	golang.org/x/sys v0.22.0
 )
 
 require (
@@ -17,6 +18,5 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	golang.org/x/sys v0.22.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -33,10 +33,22 @@ var (
 	vergePassword = flag.String("verge.password", "", "Password for VergeOS API authentication")
 	scrapeTimeout = flag.Duration("scrape.timeout", 30*time.Second, "Timeout for scraping VergeOS API")
 	insecure      = flag.Bool("insecure", false, "Skip TLS certificate verification (use for self-signed certificates)")
+	logFile       = flag.String("log.file", "", "Write logs to this file instead of stderr (useful when running as a service).")
+	serviceAction = flag.String("service", "", "Windows service control action: install, uninstall, start, stop, run (Windows only).")
 )
 
 func main() {
 	flag.Parse()
+
+	// Redirect logging to a file when requested (services have no console).
+	if *logFile != "" {
+		f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			log.Fatalf("Failed to open log file %s: %v", *logFile, err)
+		}
+		defer f.Close()
+		log.SetOutput(f)
+	}
 
 	log.Printf("vergeos-exporter version=%s commit=%s date=%s", version, commit, date)
 
@@ -53,8 +65,28 @@ func main() {
 		*vergePassword = os.Getenv("VERGE_PASSWORD")
 	}
 
+	// Windows service control/hosting. On non-Windows platforms this is a no-op
+	// unless -service was passed, in which case it reports a clear error.
+	if handled, err := runWindowsService(*serviceAction); handled {
+		if err != nil {
+			log.Fatalf("Service error: %v", err)
+		}
+		return
+	}
+
+	// Foreground execution (all platforms).
+	if err := runExporter(nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// runExporter builds the SDK client, registers collectors, and serves metrics
+// until stop is closed, an OS signal arrives, or the HTTP server fails. It is
+// platform-neutral: main() calls it directly for foreground runs, and the
+// Windows service handler calls it with a stop channel driven by the SCM.
+func runExporter(stop <-chan struct{}) error {
 	if *vergeUsername == "" || *vergePassword == "" {
-		log.Fatal("verge.username and verge.password are required (flags or VERGE_USERNAME/VERGE_PASSWORD env vars)")
+		return fmt.Errorf("verge.username and verge.password are required (flags or VERGE_USERNAME/VERGE_PASSWORD env vars)")
 	}
 
 	if *insecure {
@@ -69,7 +101,7 @@ func main() {
 		vergeos.WithTimeout(*scrapeTimeout),
 	)
 	if err != nil {
-		log.Fatalf("Failed to create VergeOS client: %v", err)
+		return fmt.Errorf("failed to create VergeOS client: %w", err)
 	}
 
 	// Validate credentials at startup (Bug #34: fail fast with clear error message)
@@ -79,9 +111,9 @@ func main() {
 	cloudName, err := client.Settings.GetCloudName(ctx)
 	if err != nil {
 		if vergeos.IsAuthError(err) {
-			log.Fatalf("Authentication failed: check username/password for %s", *vergeURL)
+			return fmt.Errorf("authentication failed: check username/password for %s", *vergeURL)
 		}
-		log.Fatalf("Failed to connect to VergeOS API at %s: %v", *vergeURL, err)
+		return fmt.Errorf("failed to connect to VergeOS API at %s: %w", *vergeURL, err)
 	}
 	log.Printf("Successfully connected to VergeOS system: %s", cloudName)
 
@@ -94,19 +126,22 @@ func main() {
 	tenantCollector := collectors.NewTenantCollector(client, *scrapeTimeout)
 	vmCollector := collectors.NewVMCollector(client, *scrapeTimeout)
 
-	prometheus.MustRegister(nodeCollector)
-	prometheus.MustRegister(storageCollector)
-	prometheus.MustRegister(networkCollector)
-	prometheus.MustRegister(clusterCollector)
-	prometheus.MustRegister(systemCollector)
-	prometheus.MustRegister(tenantCollector)
-	prometheus.MustRegister(vmCollector)
+	// Use a dedicated registry so repeated runs don't collide on the global default.
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(nodeCollector)
+	registry.MustRegister(storageCollector)
+	registry.MustRegister(networkCollector)
+	registry.MustRegister(clusterCollector)
+	registry.MustRegister(systemCollector)
+	registry.MustRegister(tenantCollector)
+	registry.MustRegister(vmCollector)
 
-	http.Handle(*metricsPath, promhttp.HandlerFor(
-		prometheus.DefaultGatherer,
+	mux := http.NewServeMux()
+	mux.Handle(*metricsPath, promhttp.HandlerFor(
+		registry,
 		promhttp.HandlerOpts{EnableOpenMetrics: true},
 	))
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, `<html>
 			<head><title>VergeOS Exporter</title></head>
 			<body>
@@ -118,16 +153,21 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         *listenAddress,
+		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: *scrapeTimeout + 5*time.Second,
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// Graceful shutdown on SIGINT/SIGTERM
+	// Graceful shutdown on SIGINT/SIGTERM or when the caller closes stop
+	// (the latter is how the Windows service handler asks us to stop).
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-quit
+		select {
+		case <-quit:
+		case <-stop:
+		}
 		log.Println("Shutting down...")
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutdownCancel()
@@ -138,6 +178,7 @@ func main() {
 
 	log.Printf("Starting VergeOS exporter on %s", *listenAddress)
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-		log.Fatalf("Server error: %v", err)
+		return fmt.Errorf("server error: %w", err)
 	}
+	return nil
 }

--- a/service_other.go
+++ b/service_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main
+
+import "fmt"
+
+// runWindowsService is a no-op on non-Windows platforms. If the user passes
+// -service anyway, report a clear error rather than silently ignoring it.
+// Returning handled=false lets main() fall through to a normal foreground run.
+func runWindowsService(action string) (handled bool, err error) {
+	if action != "" {
+		return true, fmt.Errorf("-service is only supported on Windows")
+	}
+	return false, nil
+}

--- a/service_windows.go
+++ b/service_windows.go
@@ -1,0 +1,209 @@
+//go:build windows
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const (
+	serviceName        = "VergeOSExporter"
+	serviceDisplayName = "VergeOS Exporter"
+	serviceDescription = "Prometheus exporter for VergeOS metrics"
+)
+
+// exporterService adapts runExporter to the Windows Service Control Manager.
+type exporterService struct{}
+
+func (s *exporterService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
+	const accepted = svc.AcceptStop | svc.AcceptShutdown
+	changes <- svc.Status{State: svc.StartPending}
+
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() { done <- runExporter(stop) }()
+
+	changes <- svc.Status{State: svc.Running, Accepts: accepted}
+	for {
+		select {
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Interrogate:
+				changes <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				changes <- svc.Status{State: svc.StopPending}
+				close(stop)
+				<-done
+				changes <- svc.Status{State: svc.Stopped}
+				return false, 0
+			}
+		case err := <-done:
+			// The exporter exited on its own (startup failure or server error).
+			if err != nil {
+				return false, 1
+			}
+			changes <- svc.Status{State: svc.Stopped}
+			return false, 0
+		}
+	}
+}
+
+// runWindowsService handles service management actions and hosting under the SCM.
+// It returns handled=true when it has taken over execution (so main() should
+// return), or handled=false to fall through to a normal foreground run.
+func runWindowsService(action string) (handled bool, err error) {
+	switch strings.ToLower(action) {
+	case "install":
+		return true, installService()
+	case "uninstall", "remove":
+		return true, removeService()
+	case "start":
+		return true, startService()
+	case "stop":
+		return true, stopService()
+	case "run":
+		return true, svc.Run(serviceName, &exporterService{})
+	case "":
+		// Auto-detect: if the SCM launched us, host the service; otherwise run
+		// in the foreground exactly like on any other platform.
+		isService, derr := svc.IsWindowsService()
+		if derr != nil {
+			return false, fmt.Errorf("failed to determine service context: %w", derr)
+		}
+		if isService {
+			return true, svc.Run(serviceName, &exporterService{})
+		}
+		return false, nil
+	default:
+		return true, fmt.Errorf("unknown -service action %q (install|uninstall|start|stop|run)", action)
+	}
+}
+
+// serviceArgs reconstructs the flags the operator passed at install time so the
+// SCM launches the service with the same configuration. The -service flag
+// itself is replaced with "-service=run".
+func serviceArgs() []string {
+	args := []string{"-service=run"}
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "service" {
+			return
+		}
+		args = append(args, "-"+f.Name+"="+f.Value.String())
+	})
+	return args
+}
+
+func installService() error {
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not determine executable path: %w", err)
+	}
+	exePath, err = filepath.Abs(exePath)
+	if err != nil {
+		return fmt.Errorf("could not resolve executable path: %w", err)
+	}
+
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("could not connect to service manager (run as Administrator): %w", err)
+	}
+	defer m.Disconnect()
+
+	if s, err := m.OpenService(serviceName); err == nil {
+		s.Close()
+		return fmt.Errorf("service %s already exists", serviceName)
+	}
+
+	s, err := m.CreateService(serviceName, exePath, mgr.Config{
+		DisplayName:  serviceDisplayName,
+		Description:  serviceDescription,
+		StartType:    mgr.StartAutomatic,
+		ErrorControl: mgr.ErrorNormal,
+	}, serviceArgs()...)
+	if err != nil {
+		return fmt.Errorf("could not create service: %w", err)
+	}
+	defer s.Close()
+
+	fmt.Printf("Installed service %q. Start it with:\n  %s -service=start\n", serviceName, filepath.Base(exePath))
+	return nil
+}
+
+func removeService() error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("could not connect to service manager (run as Administrator): %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		return fmt.Errorf("service %s is not installed: %w", serviceName, err)
+	}
+	defer s.Close()
+
+	if err := s.Delete(); err != nil {
+		return fmt.Errorf("could not remove service: %w", err)
+	}
+	fmt.Printf("Removed service %q.\n", serviceName)
+	return nil
+}
+
+func startService() error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("could not connect to service manager (run as Administrator): %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		return fmt.Errorf("service %s is not installed: %w", serviceName, err)
+	}
+	defer s.Close()
+
+	if err := s.Start(); err != nil {
+		return fmt.Errorf("could not start service: %w", err)
+	}
+	fmt.Printf("Started service %q.\n", serviceName)
+	return nil
+}
+
+func stopService() error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("could not connect to service manager (run as Administrator): %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		return fmt.Errorf("service %s is not installed: %w", serviceName, err)
+	}
+	defer s.Close()
+
+	status, err := s.Control(svc.Stop)
+	if err != nil {
+		return fmt.Errorf("could not stop service: %w", err)
+	}
+
+	// Wait up to 15s for the service to report Stopped.
+	deadline := 30
+	for status.State != svc.Stopped && deadline > 0 {
+		time.Sleep(500 * time.Millisecond)
+		deadline--
+		if status, err = s.Query(); err != nil {
+			return fmt.Errorf("could not query service status: %w", err)
+		}
+	}
+	fmt.Printf("Stopped service %q.\n", serviceName)
+	return nil
+}


### PR DESCRIPTION
## Summary

Fixes #50. The README pointed at `nssm.cc` for running the exporter as a Windows service, but that site is now defunct. Rather than swap in another third-party wrapper, this adds **built-in Windows service support** so the exporter manages itself — no external download that can go dead.

### What changed

- **New `-service` flag**: `install`, `uninstall`, `start`, `stop`, `run`. Talks directly to the Windows Service Control Manager via `golang.org/x/sys/windows/svc`. It auto-detects when launched by the SCM and hosts itself; `install` captures the config flags you pass and reuses them on every start (created with automatic startup).
- **New `-log.file` flag**: redirects logging to a file, since a Windows service has no console.
- **Shared core refactor**: server startup moved into a platform-neutral `runExporter(stop)` used by both the foreground path and the service handler. It returns errors instead of calling `log.Fatal`, and uses a dedicated Prometheus registry + `http.ServeMux` instead of the global defaults.
- **Cross-platform safe**: Windows code is build-tagged (`service_windows.go`); a `service_other.go` stub keeps every other OS compiling and behaving exactly as before, reporting a clear error if `-service` is passed on a non-Windows platform.
- **Docs**: the README "Running as a Windows Service" section is rewritten around the built-in commands. All NSSM references removed.
- `golang.org/x/sys` promoted from indirect to direct in `go.mod` (same version, no new transitive dependencies).

### Usage

```powershell
.\vergeos-exporter.exe -service=install -verge.url="https://VERGEURL" -verge.username="admin" -verge.password="PASSWORD" -log.file="C:\Program Files\vergeos-exporter\logs\exporter.log"
.\vergeos-exporter.exe -service=start
.\vergeos-exporter.exe -service=stop
.\vergeos-exporter.exe -service=uninstall
```

## Test plan

- [x] `go build ./...` and `go vet ./...` clean on both `linux/amd64` and `windows/amd64`
- [x] `go test ./...` passes
- [x] Foreground run against a mock VergeOS API: connects, serves `vergeos_*` metrics with the `system_name` label, root page returns 200
- [x] Graceful shutdown on SIGTERM
- [x] `-log.file` redirects all logging to the given file
- [x] `-service` on non-Windows returns a clear "only supported on Windows" error
- [ ] Windows SCM install/start/stop/uninstall verified on a Windows host (not runnable in CI here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iE7sD7kYCV1Yh3gaM9Cn6

---
_Generated by [Claude Code](https://claude.ai/code/session_018iE7sD7kYCV1Yh3gaM9Cn6)_