### PR TITLE
feat: add VNet-level network metrics (#52)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ The `MustNewConstMetric` pattern (vs persistent metric objects) is intentional â
 | System | `collectors/system.go` | `Settings`, `UpdateSettings`, `UpdateSourcePackages` |
 | Tenant | `collectors/tenant.go` | `Tenants`, `TenantNodes`, `TenantStatus`, `TenantStatsHistoryShort`, `TenantStorage`, `TenantLayer2Networks`, `MachineStats`, `MachineStatus` |
 | VM | `collectors/vm.go` | `VMs`, `MachineStats`, `MachineStatus`, `MachineNICs`, `Clusters` |
+| VNet | `collectors/vnet.go` | `Networks` |
 
 ### Test Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ The `MustNewConstMetric` pattern (vs persistent metric objects) is intentional â
 | System | `collectors/system.go` | `Settings`, `UpdateSettings`, `UpdateSourcePackages` |
 | Tenant | `collectors/tenant.go` | `Tenants`, `TenantNodes`, `TenantStatus`, `TenantStatsHistoryShort`, `TenantStorage`, `TenantLayer2Networks`, `MachineStats`, `MachineStatus` |
 | VM | `collectors/vm.go` | `VMs`, `MachineStats`, `MachineStatus`, `MachineNICs`, `Clusters` |
-| VNet | `collectors/vnet.go` | `Networks` |
+| VNet | `collectors/vnet.go` | `Networks`, `MachineNICs` |
 
 ### Test Pattern
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Prometheus exporter for VergeOS that collects metrics about VSAN tiers, cluste
   - Process and service status
 
 - Virtual Network (VNet) Metrics:
-  - Enabled/power/monitoring state per network
+  - Enabled/monitoring state per network
   - Gateway monitoring quality, latency, and packet-loss stats
 
 ## Metrics Format

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A Prometheus exporter for VergeOS that collects metrics about VSAN tiers, cluste
   - Network throughput and latency
   - Process and service status
 
+- Virtual Network (VNet) Metrics:
+  - Enabled/power/monitoring state per network
+  - Gateway monitoring quality, latency, and packet-loss stats
+
 ## Metrics Format
 
 The exporter supports both standard Prometheus text format and [OpenMetrics](https://openmetrics.io/) format via content negotiation. Prometheus 2.5.0+ will automatically request OpenMetrics format. Older scrapers continue to receive standard Prometheus text format — no configuration required.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The exporter supports both standard Prometheus text format and [OpenMetrics](htt
 
 Prebuilt binaries for Linux, Windows, and macOS (both amd64 and arm64) are available on the [Releases](https://github.com/verge-io/vergeos-exporter/releases) page.
 
-Note that the version number is included in the filename (e.g., vergeos-exporter_1.1.6_Darwin_x86_64.tar.gz), so ensure you download the correct version for your system.
+Note that the version number is included in the filename (e.g., vergeos-exporter_2.1.0_Darwin_x86_64.tar.gz), so ensure you download the correct version for your system.
 
 1. Download the appropriate binary for your system
 2. Extract the archive:
@@ -68,7 +68,7 @@ docker run --rm -p 9888:9888 \
 
 Available tags:
 - `ghcr.io/verge-io/vergeos-exporter:latest` — most recent release
-- `ghcr.io/verge-io/vergeos-exporter:1.2.0` — specific version (no `v` prefix)
+- `ghcr.io/verge-io/vergeos-exporter:2.1.0` — specific version (no `v` prefix)
 
 See `examples/docker-compose/` for a complete monitoring stack with Prometheus and Grafana.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ A Prometheus exporter for VergeOS that collects metrics about VSAN tiers, cluste
   - Process and service status
 
 - Virtual Network (VNet) Metrics:
-  - Enabled/monitoring state per network
+  - Enabled/power/monitoring state per network
+  - Router NIC TX/RX bytes and packets
   - Gateway monitoring quality, latency, and packet-loss stats
 
 ## Metrics Format

--- a/collectors/vnet.go
+++ b/collectors/vnet.go
@@ -1,6 +1,7 @@
 package collectors
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
@@ -193,16 +194,23 @@ func (vc *VNetCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	// Map NIC key -> NIC so each vnet's router NIC stats can be joined
-	// without per-vnet API calls.
-	allNICs, err := vc.Client().MachineNICs.List(ctx)
-	if err != nil {
-		log.Printf("VNetCollector: Error fetching NICs: %v", err)
-		return
+	// without per-vnet API calls. Best-effort: a NIC fetch failure only
+	// drops the traffic counters, not the rest of the VNet metrics.
+	nicByKey := make(map[int]vergeos.MachineNIC)
+	if allNICs, err := vc.Client().MachineNICs.List(ctx); err != nil {
+		log.Printf("VNetCollector: Error fetching NICs (traffic counters skipped): %v", err)
+	} else {
+		for _, nic := range allNICs {
+			nicByKey[int(nic.Key)] = nic
+		}
 	}
-	nicByKey := make(map[int]vergeos.MachineNIC, len(allNICs))
-	for _, nic := range allNICs {
-		nicByKey[int(nic.Key)] = nic
+
+	type monitoredVNet struct {
+		id     int
+		name   string
+		labels []string
 	}
+	var monitored []monitoredVNet
 
 	for _, network := range networks {
 		clusterName := clusterMap[int(network.Cluster)]
@@ -245,52 +253,71 @@ func (vc *VNetCollector) Collect(ch chan<- prometheus.Metric) {
 			)
 		}
 
-		if !network.MonitorGateway {
-			continue
+		if network.MonitorGateway {
+			monitored = append(monitored, monitoredVNet{id: int(network.ID), name: network.Name, labels: labels})
 		}
-
-		stats, err := vc.Client().Networks.GetLatestStatistics(ctx, int(network.ID))
-		if err != nil {
-			log.Printf("VNetCollector: Error fetching monitor stats for network %s: %v", network.Name, err)
-			continue
-		}
-		if stats == nil {
-			// Monitoring enabled but no stats row yet (e.g. network just started)
-			continue
-		}
-
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorSent, prometheus.GaugeValue, float64(stats.Sent), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorQuality, prometheus.GaugeValue, float64(stats.Quality), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorDroppedPct, prometheus.GaugeValue, float64(stats.DroppedPct), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorLatencyUsecAvg, prometheus.GaugeValue, float64(stats.LatencyUSAvg), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorLatencyUsecPeak, prometheus.GaugeValue, float64(stats.LatencyUSPeak), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorDuplicates, prometheus.GaugeValue, float64(stats.Duplicates), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorTruncated, prometheus.GaugeValue, float64(stats.Truncated), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorDropped, prometheus.GaugeValue, float64(stats.Dropped), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorBadChecksums, prometheus.GaugeValue, float64(stats.BadChecksums), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorBadData, prometheus.GaugeValue, float64(stats.BadData), labels...,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.monitorTimestampSeconds, prometheus.GaugeValue, float64(stats.Timestamp), labels...,
-		)
 	}
+
+	// Fetch latest monitor stats with bounded concurrency so many monitored
+	// networks don't serially exhaust the scrape timeout (the SDK issues one
+	// HTTP request per network).
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8)
+	for _, m := range monitored {
+		wg.Add(1)
+		go func(m monitoredVNet) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			vc.collectMonitorStats(ctx, ch, m.id, m.name, m.labels)
+		}(m)
+	}
+	wg.Wait()
+}
+
+// collectMonitorStats emits the latest gateway-monitoring stats for one network.
+func (vc *VNetCollector) collectMonitorStats(ctx context.Context, ch chan<- prometheus.Metric, id int, name string, labels []string) {
+	stats, err := vc.Client().Networks.GetLatestStatistics(ctx, id)
+	if err != nil {
+		log.Printf("VNetCollector: Error fetching monitor stats for network %s: %v", name, err)
+		return
+	}
+	if stats == nil {
+		// Monitoring enabled but no stats row yet (e.g. network just started)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorSent, prometheus.GaugeValue, float64(stats.Sent), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorQuality, prometheus.GaugeValue, float64(stats.Quality), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorDroppedPct, prometheus.GaugeValue, float64(stats.DroppedPct), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorLatencyUsecAvg, prometheus.GaugeValue, float64(stats.LatencyUSAvg), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorLatencyUsecPeak, prometheus.GaugeValue, float64(stats.LatencyUSPeak), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorDuplicates, prometheus.GaugeValue, float64(stats.Duplicates), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorTruncated, prometheus.GaugeValue, float64(stats.Truncated), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorDropped, prometheus.GaugeValue, float64(stats.Dropped), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorBadChecksums, prometheus.GaugeValue, float64(stats.BadChecksums), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorBadData, prometheus.GaugeValue, float64(stats.BadData), labels...,
+	)
+	ch <- prometheus.MustNewConstMetric(
+		vc.monitorTimestampSeconds, prometheus.GaugeValue, float64(stats.Timestamp), labels...,
+	)
 }

--- a/collectors/vnet.go
+++ b/collectors/vnet.go
@@ -22,7 +22,14 @@ type VNetCollector struct {
 
 	// Inventory/config metrics
 	vnetEnabled        *prometheus.Desc
+	vnetPowerState     *prometheus.Desc
 	vnetMonitorGateway *prometheus.Desc
+
+	// Router NIC traffic counters
+	vnetTxBytes   *prometheus.Desc
+	vnetRxBytes   *prometheus.Desc
+	vnetTxPackets *prometheus.Desc
+	vnetRxPackets *prometheus.Desc
 
 	// Gateway monitoring metrics (latest sample per monitored network)
 	monitorSent             *prometheus.Desc
@@ -47,6 +54,31 @@ func NewVNetCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VNet
 		vnetEnabled: prometheus.NewDesc(
 			"vergeos_vnet_enabled",
 			"Whether the virtual network is enabled (1=enabled, 0=disabled)",
+			labels, nil,
+		),
+		vnetPowerState: prometheus.NewDesc(
+			"vergeos_vnet_powerstate",
+			"Whether the virtual network's router is running (1=running, 0=stopped)",
+			labels, nil,
+		),
+		vnetTxBytes: prometheus.NewDesc(
+			"vergeos_vnet_tx_bytes_total",
+			"Total bytes transmitted by the virtual network's router NIC",
+			labels, nil,
+		),
+		vnetRxBytes: prometheus.NewDesc(
+			"vergeos_vnet_rx_bytes_total",
+			"Total bytes received by the virtual network's router NIC",
+			labels, nil,
+		),
+		vnetTxPackets: prometheus.NewDesc(
+			"vergeos_vnet_tx_packets_total",
+			"Total packets transmitted by the virtual network's router NIC",
+			labels, nil,
+		),
+		vnetRxPackets: prometheus.NewDesc(
+			"vergeos_vnet_rx_packets_total",
+			"Total packets received by the virtual network's router NIC",
 			labels, nil,
 		),
 		vnetMonitorGateway: prometheus.NewDesc(
@@ -115,7 +147,12 @@ func NewVNetCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VNet
 // Describe implements prometheus.Collector.
 func (vc *VNetCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- vc.vnetEnabled
+	ch <- vc.vnetPowerState
 	ch <- vc.vnetMonitorGateway
+	ch <- vc.vnetTxBytes
+	ch <- vc.vnetRxBytes
+	ch <- vc.vnetTxPackets
+	ch <- vc.vnetRxPackets
 	ch <- vc.monitorSent
 	ch <- vc.monitorQuality
 	ch <- vc.monitorDroppedPct
@@ -155,6 +192,18 @@ func (vc *VNetCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	// Map NIC key -> NIC so each vnet's router NIC stats can be joined
+	// without per-vnet API calls.
+	allNICs, err := vc.Client().MachineNICs.List(ctx)
+	if err != nil {
+		log.Printf("VNetCollector: Error fetching NICs: %v", err)
+		return
+	}
+	nicByKey := make(map[int]vergeos.MachineNIC, len(allNICs))
+	for _, nic := range allNICs {
+		nicByKey[int(nic.Key)] = nic
+	}
+
 	for _, network := range networks {
 		clusterName := clusterMap[int(network.Cluster)]
 		if clusterName == "" {
@@ -169,15 +218,32 @@ func (vc *VNetCollector) Collect(ch chan<- prometheus.Metric) {
 			vc.vnetEnabled, prometheus.GaugeValue,
 			boolToFloat64(network.Enabled), labels...,
 		)
-		// The vnets `powerstate` DB field is not maintained by the platform
-		// (always false on live systems); true running state is
-		// machine#status#status, which the SDK does not expose yet.
-		// TODO(govergeos): emit vergeos_vnet_powerstate once the SDK exposes
-		// the vnet machine status.
+		// Running (machine#status#running) is the true state; the vnets
+		// `powerstate` DB field is not maintained by the platform.
+		ch <- prometheus.MustNewConstMetric(
+			vc.vnetPowerState, prometheus.GaugeValue,
+			boolToFloat64(network.Running), labels...,
+		)
 		ch <- prometheus.MustNewConstMetric(
 			vc.vnetMonitorGateway, prometheus.GaugeValue,
 			boolToFloat64(network.MonitorGateway), labels...,
 		)
+
+		// Router NIC traffic counters (primary NIC only; DMZ NIC not exposed)
+		if nic, ok := nicByKey[int(network.NIC)]; ok && network.NIC != 0 && nic.Stats != nil {
+			ch <- prometheus.MustNewConstMetric(
+				vc.vnetTxBytes, prometheus.CounterValue, float64(nic.Stats.TxBytes), labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				vc.vnetRxBytes, prometheus.CounterValue, float64(nic.Stats.RxBytes), labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				vc.vnetTxPackets, prometheus.CounterValue, float64(nic.Stats.TxPckts), labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				vc.vnetRxPackets, prometheus.CounterValue, float64(nic.Stats.RxPckts), labels...,
+			)
+		}
 
 		if !network.MonitorGateway {
 			continue

--- a/collectors/vnet.go
+++ b/collectors/vnet.go
@@ -1,0 +1,236 @@
+package collectors
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	vergeos "github.com/verge-io/govergeos"
+)
+
+var _ prometheus.Collector = (*VNetCollector)(nil)
+
+// VNetCollector collects metrics about VergeOS virtual networks (VNets):
+// inventory/config state for every network, plus the latest gateway-monitoring
+// stats for networks with gateway monitoring enabled.
+type VNetCollector struct {
+	BaseCollector
+	mutex sync.Mutex
+
+	// Inventory/config metrics
+	vnetEnabled        *prometheus.Desc
+	vnetPowerState     *prometheus.Desc
+	vnetMonitorGateway *prometheus.Desc
+
+	// Gateway monitoring metrics (latest sample per monitored network)
+	monitorSent             *prometheus.Desc
+	monitorQuality          *prometheus.Desc
+	monitorDroppedPct       *prometheus.Desc
+	monitorLatencyUsecAvg   *prometheus.Desc
+	monitorLatencyUsecPeak  *prometheus.Desc
+	monitorDuplicates       *prometheus.Desc
+	monitorTruncated        *prometheus.Desc
+	monitorDropped          *prometheus.Desc
+	monitorBadChecksums     *prometheus.Desc
+	monitorBadData          *prometheus.Desc
+	monitorTimestampSeconds *prometheus.Desc
+}
+
+// NewVNetCollector creates a new VNetCollector.
+func NewVNetCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VNetCollector {
+	labels := []string{"system_name", "vnet_name", "vnet_id", "cluster", "type", "layer2_type"}
+
+	return &VNetCollector{
+		BaseCollector: *NewBaseCollector(client, scrapeTimeout),
+		vnetEnabled: prometheus.NewDesc(
+			"vergeos_vnet_enabled",
+			"Whether the virtual network is enabled (1=enabled, 0=disabled)",
+			labels, nil,
+		),
+		vnetPowerState: prometheus.NewDesc(
+			"vergeos_vnet_powerstate",
+			"Whether the virtual network is running (1=running, 0=stopped)",
+			labels, nil,
+		),
+		vnetMonitorGateway: prometheus.NewDesc(
+			"vergeos_vnet_monitor_gateway",
+			"Whether gateway monitoring is enabled for the virtual network (1=enabled, 0=disabled)",
+			labels, nil,
+		),
+		monitorSent: prometheus.NewDesc(
+			"vergeos_vnet_monitor_sent",
+			"Monitoring packets sent in the latest gateway-monitoring sample",
+			labels, nil,
+		),
+		monitorQuality: prometheus.NewDesc(
+			"vergeos_vnet_monitor_quality",
+			"Gateway network quality percentage (100 - dropped_pct) from the latest sample",
+			labels, nil,
+		),
+		monitorDroppedPct: prometheus.NewDesc(
+			"vergeos_vnet_monitor_dropped_pct",
+			"Percentage of dropped monitoring packets in the latest sample",
+			labels, nil,
+		),
+		monitorLatencyUsecAvg: prometheus.NewDesc(
+			"vergeos_vnet_monitor_latency_usec_avg",
+			"Average gateway latency in microseconds from the latest sample",
+			labels, nil,
+		),
+		monitorLatencyUsecPeak: prometheus.NewDesc(
+			"vergeos_vnet_monitor_latency_usec_peak",
+			"Peak gateway latency in microseconds from the latest sample",
+			labels, nil,
+		),
+		monitorDuplicates: prometheus.NewDesc(
+			"vergeos_vnet_monitor_duplicates",
+			"Duplicate monitoring packets in the latest sample",
+			labels, nil,
+		),
+		monitorTruncated: prometheus.NewDesc(
+			"vergeos_vnet_monitor_truncated",
+			"Truncated monitoring packets in the latest sample",
+			labels, nil,
+		),
+		monitorDropped: prometheus.NewDesc(
+			"vergeos_vnet_monitor_dropped",
+			"Dropped monitoring packets in the latest sample",
+			labels, nil,
+		),
+		monitorBadChecksums: prometheus.NewDesc(
+			"vergeos_vnet_monitor_bad_checksums",
+			"Monitoring packets with bad checksums in the latest sample",
+			labels, nil,
+		),
+		monitorBadData: prometheus.NewDesc(
+			"vergeos_vnet_monitor_bad_data",
+			"Monitoring packets with bad data in the latest sample",
+			labels, nil,
+		),
+		monitorTimestampSeconds: prometheus.NewDesc(
+			"vergeos_vnet_monitor_timestamp_seconds",
+			"Unix timestamp of the latest gateway-monitoring sample",
+			labels, nil,
+		),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (vc *VNetCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- vc.vnetEnabled
+	ch <- vc.vnetPowerState
+	ch <- vc.vnetMonitorGateway
+	ch <- vc.monitorSent
+	ch <- vc.monitorQuality
+	ch <- vc.monitorDroppedPct
+	ch <- vc.monitorLatencyUsecAvg
+	ch <- vc.monitorLatencyUsecPeak
+	ch <- vc.monitorDuplicates
+	ch <- vc.monitorTruncated
+	ch <- vc.monitorDropped
+	ch <- vc.monitorBadChecksums
+	ch <- vc.monitorBadData
+	ch <- vc.monitorTimestampSeconds
+}
+
+// Collect implements prometheus.Collector.
+func (vc *VNetCollector) Collect(ch chan<- prometheus.Metric) {
+	vc.mutex.Lock()
+	defer vc.mutex.Unlock()
+
+	ctx, cancel := vc.ScrapeContext()
+	defer cancel()
+
+	systemName, err := vc.GetSystemName(ctx)
+	if err != nil {
+		log.Printf("VNetCollector: Error getting system name: %v", err)
+		return
+	}
+
+	clusterMap, err := vc.BuildClusterMap(ctx)
+	if err != nil {
+		log.Printf("VNetCollector: Error building cluster map: %v", err)
+		return
+	}
+
+	networks, err := vc.Client().Networks.List(ctx)
+	if err != nil {
+		log.Printf("VNetCollector: Error fetching networks: %v", err)
+		return
+	}
+
+	for _, network := range networks {
+		clusterName := clusterMap[int(network.Cluster)]
+		if clusterName == "" {
+			clusterName = fmt.Sprintf("cluster_%d", network.Cluster)
+		}
+		labels := []string{
+			systemName, network.Name, strconv.Itoa(int(network.ID)),
+			clusterName, network.Type, network.Layer2Type,
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			vc.vnetEnabled, prometheus.GaugeValue,
+			boolToFloat64(network.Enabled), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.vnetPowerState, prometheus.GaugeValue,
+			boolToFloat64(network.PowerState), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.vnetMonitorGateway, prometheus.GaugeValue,
+			boolToFloat64(network.MonitorGateway), labels...,
+		)
+
+		if !network.MonitorGateway {
+			continue
+		}
+
+		stats, err := vc.Client().Networks.GetLatestStatistics(ctx, int(network.ID))
+		if err != nil {
+			log.Printf("VNetCollector: Error fetching monitor stats for network %s: %v", network.Name, err)
+			continue
+		}
+		if stats == nil {
+			// Monitoring enabled but no stats row yet (e.g. network just started)
+			continue
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorSent, prometheus.GaugeValue, float64(stats.Sent), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorQuality, prometheus.GaugeValue, float64(stats.Quality), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorDroppedPct, prometheus.GaugeValue, float64(stats.DroppedPct), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorLatencyUsecAvg, prometheus.GaugeValue, float64(stats.LatencyUSAvg), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorLatencyUsecPeak, prometheus.GaugeValue, float64(stats.LatencyUSPeak), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorDuplicates, prometheus.GaugeValue, float64(stats.Duplicates), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorTruncated, prometheus.GaugeValue, float64(stats.Truncated), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorDropped, prometheus.GaugeValue, float64(stats.Dropped), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorBadChecksums, prometheus.GaugeValue, float64(stats.BadChecksums), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorBadData, prometheus.GaugeValue, float64(stats.BadData), labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			vc.monitorTimestampSeconds, prometheus.GaugeValue, float64(stats.Timestamp), labels...,
+		)
+	}
+}

--- a/collectors/vnet.go
+++ b/collectors/vnet.go
@@ -22,7 +22,6 @@ type VNetCollector struct {
 
 	// Inventory/config metrics
 	vnetEnabled        *prometheus.Desc
-	vnetPowerState     *prometheus.Desc
 	vnetMonitorGateway *prometheus.Desc
 
 	// Gateway monitoring metrics (latest sample per monitored network)
@@ -48,11 +47,6 @@ func NewVNetCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VNet
 		vnetEnabled: prometheus.NewDesc(
 			"vergeos_vnet_enabled",
 			"Whether the virtual network is enabled (1=enabled, 0=disabled)",
-			labels, nil,
-		),
-		vnetPowerState: prometheus.NewDesc(
-			"vergeos_vnet_powerstate",
-			"Whether the virtual network is running (1=running, 0=stopped)",
 			labels, nil,
 		),
 		vnetMonitorGateway: prometheus.NewDesc(
@@ -121,7 +115,6 @@ func NewVNetCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VNet
 // Describe implements prometheus.Collector.
 func (vc *VNetCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- vc.vnetEnabled
-	ch <- vc.vnetPowerState
 	ch <- vc.vnetMonitorGateway
 	ch <- vc.monitorSent
 	ch <- vc.monitorQuality
@@ -176,10 +169,11 @@ func (vc *VNetCollector) Collect(ch chan<- prometheus.Metric) {
 			vc.vnetEnabled, prometheus.GaugeValue,
 			boolToFloat64(network.Enabled), labels...,
 		)
-		ch <- prometheus.MustNewConstMetric(
-			vc.vnetPowerState, prometheus.GaugeValue,
-			boolToFloat64(network.PowerState), labels...,
-		)
+		// The vnets `powerstate` DB field is not maintained by the platform
+		// (always false on live systems); true running state is
+		// machine#status#status, which the SDK does not expose yet.
+		// TODO(govergeos): emit vergeos_vnet_powerstate once the SDK exposes
+		// the vnet machine status.
 		ch <- prometheus.MustNewConstMetric(
 			vc.vnetMonitorGateway, prometheus.GaugeValue,
 			boolToFloat64(network.MonitorGateway), labels...,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
-	github.com/verge-io/govergeos v0.2.0
+	github.com/verge-io/govergeos v0.3.0
 	golang.org/x/sys v0.22.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
 github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/verge-io/govergeos v0.2.0 h1:OCf3nsN8UNB/zndhbwmuZ+vC57Ct4OZH16FjnsgebqA=
-github.com/verge-io/govergeos v0.2.0/go.mod h1:iMDZ50feEQ57fuqGmvtsAUUYYBz000nQ8kqI4Y8bT8U=
+github.com/verge-io/govergeos v0.3.0 h1:7JiFB0339xjbsZQg4DZzbwPIpug7PNj17WaU7vmAXSA=
+github.com/verge-io/govergeos v0.3.0/go.mod h1:iMDZ50feEQ57fuqGmvtsAUUYYBz000nQ8kqI4Y8bT8U=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=

--- a/main.go
+++ b/main.go
@@ -125,6 +125,7 @@ func runExporter(stop <-chan struct{}) error {
 	systemCollector := collectors.NewSystemCollector(client, *scrapeTimeout)
 	tenantCollector := collectors.NewTenantCollector(client, *scrapeTimeout)
 	vmCollector := collectors.NewVMCollector(client, *scrapeTimeout)
+	vnetCollector := collectors.NewVNetCollector(client, *scrapeTimeout)
 
 	// Use a dedicated registry so repeated runs don't collide on the global default.
 	registry := prometheus.NewRegistry()
@@ -135,6 +136,7 @@ func runExporter(stop <-chan struct{}) error {
 	registry.MustRegister(systemCollector)
 	registry.MustRegister(tenantCollector)
 	registry.MustRegister(vmCollector)
+	registry.MustRegister(vnetCollector)
 
 	mux := http.NewServeMux()
 	mux.Handle(*metricsPath, promhttp.HandlerFor(

--- a/metrics.md
+++ b/metrics.md
@@ -62,8 +62,9 @@ All VNet metrics are labeled by `system_name`, `vnet_name`, `vnet_id`, `cluster`
 
 Inventory/config (emitted for every virtual network):
 - **VNet Enabled**: `vergeos_vnet_enabled` (Gauge, 1=enabled)
-- **VNet Power State**: `vergeos_vnet_powerstate` (Gauge, 1=running)
 - **VNet Gateway Monitoring Enabled**: `vergeos_vnet_monitor_gateway` (Gauge, 1=enabled)
+
+A power-state metric is intentionally not exposed yet: the `/vnets` `powerstate` field is not maintained by the platform, and the true running state (`machine#status#status`) is not yet available through the SDK (verge-io/govergeos#34).
 
 Gateway monitoring (emitted only for networks with gateway monitoring enabled *and* at least one stats sample available; values are from the latest per-interval sample, so they are gauges, not cumulative counters):
 - **Monitor Packets Sent**: `vergeos_vnet_monitor_sent` (Gauge)

--- a/metrics.md
+++ b/metrics.md
@@ -62,9 +62,14 @@ All VNet metrics are labeled by `system_name`, `vnet_name`, `vnet_id`, `cluster`
 
 Inventory/config (emitted for every virtual network):
 - **VNet Enabled**: `vergeos_vnet_enabled` (Gauge, 1=enabled)
+- **VNet Power State**: `vergeos_vnet_powerstate` (Gauge, 1=running; derived from the router machine status, not the unmaintained `/vnets` `powerstate` field)
 - **VNet Gateway Monitoring Enabled**: `vergeos_vnet_monitor_gateway` (Gauge, 1=enabled)
 
-A power-state metric is intentionally not exposed yet: the `/vnets` `powerstate` field is not maintained by the platform, and the true running state (`machine#status#status`) is not yet available through the SDK (verge-io/govergeos#34).
+Router NIC traffic (emitted when the network has a router NIC with stats; counts traffic through the vnet router's primary NIC — DMZ NIC traffic is not included):
+- **VNet Transmit Bytes**: `vergeos_vnet_tx_bytes_total` (Counter)
+- **VNet Receive Bytes**: `vergeos_vnet_rx_bytes_total` (Counter)
+- **VNet Transmit Packets**: `vergeos_vnet_tx_packets_total` (Counter)
+- **VNet Receive Packets**: `vergeos_vnet_rx_packets_total` (Counter)
 
 Gateway monitoring (emitted only for networks with gateway monitoring enabled *and* at least one stats sample available; values are from the latest per-interval sample, so they are gauges, not cumulative counters):
 - **Monitor Packets Sent**: `vergeos_vnet_monitor_sent` (Gauge)
@@ -79,7 +84,6 @@ Gateway monitoring (emitted only for networks with gateway monitoring enabled *a
 - **Monitor Bad Data**: `vergeos_vnet_monitor_bad_data` (Gauge)
 - **Monitor Sample Timestamp**: `vergeos_vnet_monitor_timestamp_seconds` (Gauge, Unix timestamp)
 
-Note: the VergeOS API does not expose VNet-level TX/RX byte or packet counters — only gateway-monitoring quality/latency/drop data (`/vnet_monitor_stats_history_short`). For traffic counters, use the physical NIC (`vergeos_nic_*`) and VM NIC (`vergeos_vm_nic_*`) metrics.
 ---
 ## VSAN Tiers Overview
 - **VSAN Tier Capacity**: `vergeos_vsan_tier_capacity` (Gauge, labeled by `system_name`, `tier`, and `description`)

--- a/metrics.md
+++ b/metrics.md
@@ -56,6 +56,30 @@ All drive metrics include the following labels:
 - **NIC Receive Bytes**: `vergeos_nic_rx_bytes_total` (Counter, labeled by `system_name`, `cluster`, `node_name`, and `interface`)
 - **NIC Status**: `vergeos_nic_status` (Gauge, labeled by `system_name`, `cluster`, `node_name`, and `interface`)
 ---
+## VNet Metrics
+
+All VNet metrics are labeled by `system_name`, `vnet_name`, `vnet_id`, `cluster`, `type`, and `layer2_type`.
+
+Inventory/config (emitted for every virtual network):
+- **VNet Enabled**: `vergeos_vnet_enabled` (Gauge, 1=enabled)
+- **VNet Power State**: `vergeos_vnet_powerstate` (Gauge, 1=running)
+- **VNet Gateway Monitoring Enabled**: `vergeos_vnet_monitor_gateway` (Gauge, 1=enabled)
+
+Gateway monitoring (emitted only for networks with gateway monitoring enabled *and* at least one stats sample available; values are from the latest per-interval sample, so they are gauges, not cumulative counters):
+- **Monitor Packets Sent**: `vergeos_vnet_monitor_sent` (Gauge)
+- **Monitor Quality**: `vergeos_vnet_monitor_quality` (Gauge, percentage, 100 - dropped_pct)
+- **Monitor Dropped Percentage**: `vergeos_vnet_monitor_dropped_pct` (Gauge, percentage)
+- **Monitor Average Latency**: `vergeos_vnet_monitor_latency_usec_avg` (Gauge, microseconds)
+- **Monitor Peak Latency**: `vergeos_vnet_monitor_latency_usec_peak` (Gauge, microseconds)
+- **Monitor Duplicate Packets**: `vergeos_vnet_monitor_duplicates` (Gauge)
+- **Monitor Truncated Packets**: `vergeos_vnet_monitor_truncated` (Gauge)
+- **Monitor Dropped Packets**: `vergeos_vnet_monitor_dropped` (Gauge)
+- **Monitor Bad Checksums**: `vergeos_vnet_monitor_bad_checksums` (Gauge)
+- **Monitor Bad Data**: `vergeos_vnet_monitor_bad_data` (Gauge)
+- **Monitor Sample Timestamp**: `vergeos_vnet_monitor_timestamp_seconds` (Gauge, Unix timestamp)
+
+Note: the VergeOS API does not expose VNet-level TX/RX byte or packet counters — only gateway-monitoring quality/latency/drop data (`/vnet_monitor_stats_history_short`). For traffic counters, use the physical NIC (`vergeos_nic_*`) and VM NIC (`vergeos_vm_nic_*`) metrics.
+---
 ## VSAN Tiers Overview
 - **VSAN Tier Capacity**: `vergeos_vsan_tier_capacity` (Gauge, labeled by `system_name`, `tier`, and `description`)
 - **VSAN Tier Used Space**: `vergeos_vsan_tier_used` (Gauge, labeled by `system_name`, `tier`, and `description`)

--- a/tests/testhelpers.go
+++ b/tests/testhelpers.go
@@ -403,6 +403,35 @@ type VMDriveMock struct {
 	Enabled       bool   `json:"enabled"`
 }
 
+// VNetMock represents a mock virtual network
+type VNetMock struct {
+	Key            int    `json:"$key"`
+	Name           string `json:"name"`
+	Enabled        bool   `json:"enabled"`
+	PowerState     bool   `json:"powerstate"`
+	Cluster        int    `json:"cluster"`
+	Type           string `json:"type"`
+	Layer2Type     string `json:"layer2_type"`
+	MonitorGateway bool   `json:"monitor_gateway"`
+}
+
+// VNetMonitorStatsMock represents a mock VNet gateway-monitoring stats record
+type VNetMonitorStatsMock struct {
+	Key           int    `json:"$key"`
+	VNet          int    `json:"vnet"`
+	Sent          uint16 `json:"sent"`
+	Quality       uint8  `json:"quality"`
+	DroppedPct    uint8  `json:"dropped_pct"`
+	LatencyUSAvg  uint32 `json:"latency_usec_avg"`
+	LatencyUSPeak uint32 `json:"latency_usec_peak"`
+	Duplicates    uint16 `json:"duplicates"`
+	Truncated     uint16 `json:"truncated"`
+	Dropped       uint16 `json:"dropped"`
+	BadChecksums  uint16 `json:"bad_checksums"`
+	BadData       uint16 `json:"bad_data"`
+	Timestamp     uint32 `json:"timestamp"`
+}
+
 // UpdateSettingsMock represents mock update settings
 type UpdateSettingsMock struct {
 	Key        int    `json:"$key"`

--- a/tests/testhelpers.go
+++ b/tests/testhelpers.go
@@ -408,7 +408,8 @@ type VNetMock struct {
 	Key            int    `json:"$key"`
 	Name           string `json:"name"`
 	Enabled        bool   `json:"enabled"`
-	PowerState     bool   `json:"powerstate"`
+	Running        bool   `json:"running"`
+	NIC            int    `json:"nic,omitempty"`
 	Cluster        int    `json:"cluster"`
 	Type           string `json:"type"`
 	Layer2Type     string `json:"layer2_type"`

--- a/tests/vnet_test.go
+++ b/tests/vnet_test.go
@@ -15,11 +15,14 @@ import (
 
 // newVNetMockServer builds a mock server serving /vnets and
 // /vnet_monitor_stats_history_short (filtered by "vnet eq <id>").
-func newVNetMockServer(t *testing.T, config MockServerConfig, clusters []ClusterMock, vnets []VNetMock, stats []VNetMonitorStatsMock) *httptest.Server {
+func newVNetMockServer(t *testing.T, config MockServerConfig, clusters []ClusterMock, vnets []VNetMock, stats []VNetMonitorStatsMock, nics []MachineNICMock) *httptest.Server {
 	return NewBaseMockServer(t, config, func(w http.ResponseWriter, r *http.Request) bool {
 		switch {
 		case strings.Contains(r.URL.Path, "/clusters"):
 			WriteJSONResponse(w, clusters)
+			return true
+		case strings.Contains(r.URL.Path, "/machine_nics"):
+			WriteJSONResponse(w, nics)
 			return true
 		case strings.Contains(r.URL.Path, "/vnet_monitor_stats_history_short"):
 			filter := r.URL.Query().Get("filter")
@@ -48,15 +51,20 @@ func TestVNetCollector_Metrics(t *testing.T) {
 	}
 
 	vnets := []VNetMock{
-		// External network with gateway monitoring and stats available
-		{Key: 10, Name: "external", Enabled: true, PowerState: true, Cluster: 1,
+		// External network with gateway monitoring, stats, and a router NIC
+		{Key: 10, Name: "external", Enabled: true, Running: true, NIC: 500, Cluster: 1,
 			Type: "external", Layer2Type: "", MonitorGateway: true},
-		// Internal network, no monitoring
-		{Key: 11, Name: "internal", Enabled: true, PowerState: false, Cluster: 1,
+		// Internal network, no monitoring, no router NIC stats
+		{Key: 11, Name: "internal", Enabled: true, Running: false, Cluster: 1,
 			Type: "internal", Layer2Type: "vxlan", MonitorGateway: false},
 		// Monitoring enabled but no stats row yet
-		{Key: 12, Name: "newnet", Enabled: false, PowerState: false, Cluster: 1,
+		{Key: 12, Name: "newnet", Enabled: false, Running: false, Cluster: 1,
 			Type: "internal", Layer2Type: "vlan", MonitorGateway: true},
+	}
+
+	nics := []MachineNICMock{
+		{Key: 500, Machine: 900, Name: "vnet10",
+			Stats: &MachineNICStatsMock{Key: 500, TxPckts: 7000, RxPckts: 8000, TxBytes: 700000, RxBytes: 800000}},
 	}
 
 	stats := []VNetMonitorStatsMock{
@@ -65,7 +73,7 @@ func TestVNetCollector_Metrics(t *testing.T) {
 			Dropped: 3, BadChecksums: 4, BadData: 5, Timestamp: 1700000000},
 	}
 
-	mockServer := newVNetMockServer(t, config, clusters, vnets, stats)
+	mockServer := newVNetMockServer(t, config, clusters, vnets, stats, nics)
 	defer mockServer.Close()
 
 	client := CreateTestSDKClient(t, mockServer.URL)
@@ -80,6 +88,46 @@ func TestVNetCollector_Metrics(t *testing.T) {
 			vergeos_vnet_enabled{cluster="cluster1",layer2_type="vlan",system_name="test-cloud",type="internal",vnet_id="12",vnet_name="newnet"} 0
 		`
 		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vnet_enabled"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("powerstate", func(t *testing.T) {
+		expected := `
+			# HELP vergeos_vnet_powerstate Whether the virtual network's router is running (1=running, 0=stopped)
+			# TYPE vergeos_vnet_powerstate gauge
+			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1
+			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="vxlan",system_name="test-cloud",type="internal",vnet_id="11",vnet_name="internal"} 0
+			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="vlan",system_name="test-cloud",type="internal",vnet_id="12",vnet_name="newnet"} 0
+		`
+		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vnet_powerstate"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("router_nic_traffic", func(t *testing.T) {
+		// Only vnet 10 has a router NIC with stats
+		expected := `
+			# HELP vergeos_vnet_tx_bytes_total Total bytes transmitted by the virtual network's router NIC
+			# TYPE vergeos_vnet_tx_bytes_total counter
+			vergeos_vnet_tx_bytes_total{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 700000
+			# HELP vergeos_vnet_rx_bytes_total Total bytes received by the virtual network's router NIC
+			# TYPE vergeos_vnet_rx_bytes_total counter
+			vergeos_vnet_rx_bytes_total{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 800000
+			# HELP vergeos_vnet_tx_packets_total Total packets transmitted by the virtual network's router NIC
+			# TYPE vergeos_vnet_tx_packets_total counter
+			vergeos_vnet_tx_packets_total{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 7000
+			# HELP vergeos_vnet_rx_packets_total Total packets received by the virtual network's router NIC
+			# TYPE vergeos_vnet_rx_packets_total counter
+			vergeos_vnet_rx_packets_total{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 8000
+		`
+		metricNames := []string{
+			"vergeos_vnet_tx_bytes_total",
+			"vergeos_vnet_rx_bytes_total",
+			"vergeos_vnet_tx_packets_total",
+			"vergeos_vnet_rx_packets_total",
+		}
+		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), metricNames...); err != nil {
 			t.Errorf("Unexpected metric values: %v", err)
 		}
 	})
@@ -172,7 +220,7 @@ func TestVNetCollector_Describe(t *testing.T) {
 		count++
 	}
 
-	if count != 13 {
-		t.Errorf("Expected 13 descriptors, got %d", count)
+	if count != 18 {
+		t.Errorf("Expected 18 descriptors, got %d", count)
 	}
 }

--- a/tests/vnet_test.go
+++ b/tests/vnet_test.go
@@ -84,19 +84,6 @@ func TestVNetCollector_Metrics(t *testing.T) {
 		}
 	})
 
-	t.Run("powerstate", func(t *testing.T) {
-		expected := `
-			# HELP vergeos_vnet_powerstate Whether the virtual network is running (1=running, 0=stopped)
-			# TYPE vergeos_vnet_powerstate gauge
-			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1
-			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="vxlan",system_name="test-cloud",type="internal",vnet_id="11",vnet_name="internal"} 0
-			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="vlan",system_name="test-cloud",type="internal",vnet_id="12",vnet_name="newnet"} 0
-		`
-		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vnet_powerstate"); err != nil {
-			t.Errorf("Unexpected metric values: %v", err)
-		}
-	})
-
 	t.Run("monitor_gateway", func(t *testing.T) {
 		expected := `
 			# HELP vergeos_vnet_monitor_gateway Whether gateway monitoring is enabled for the virtual network (1=enabled, 0=disabled)
@@ -185,7 +172,7 @@ func TestVNetCollector_Describe(t *testing.T) {
 		count++
 	}
 
-	if count != 14 {
-		t.Errorf("Expected 14 descriptors, got %d", count)
+	if count != 13 {
+		t.Errorf("Expected 13 descriptors, got %d", count)
 	}
 }

--- a/tests/vnet_test.go
+++ b/tests/vnet_test.go
@@ -202,6 +202,52 @@ func TestVNetCollector_Metrics(t *testing.T) {
 	})
 }
 
+func TestVNetCollector_NICFetchFailure(t *testing.T) {
+	config := DefaultMockConfig()
+	config.CloudName = "test-cloud"
+
+	clusters := []ClusterMock{{Key: 1, Name: "cluster1", Enabled: true}}
+	vnets := []VNetMock{
+		{Key: 10, Name: "external", Enabled: true, Running: true, NIC: 500, Cluster: 1,
+			Type: "external", Layer2Type: "", MonitorGateway: false},
+	}
+
+	mockServer := NewBaseMockServer(t, config, func(w http.ResponseWriter, r *http.Request) bool {
+		switch {
+		case strings.Contains(r.URL.Path, "/clusters"):
+			WriteJSONResponse(w, clusters)
+			return true
+		case strings.Contains(r.URL.Path, "/machine_nics"):
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return true
+		case strings.Contains(r.URL.Path, "/vnets"):
+			WriteJSONResponse(w, vnets)
+			return true
+		}
+		return false
+	})
+	defer mockServer.Close()
+
+	client := CreateTestSDKClient(t, mockServer.URL)
+	collector := collectors.NewVNetCollector(client, TestScrapeTimeout)
+
+	// Inventory metrics must survive a NIC fetch failure
+	expected := `
+		# HELP vergeos_vnet_enabled Whether the virtual network is enabled (1=enabled, 0=disabled)
+		# TYPE vergeos_vnet_enabled gauge
+		vergeos_vnet_enabled{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1
+	`
+	if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vnet_enabled"); err != nil {
+		t.Errorf("Inventory metrics missing after NIC fetch failure: %v", err)
+	}
+
+	// Traffic counters must be absent, not zero-valued or stale
+	count := testutil.CollectAndCount(collector, "vergeos_vnet_tx_bytes_total")
+	if count != 0 {
+		t.Errorf("Expected 0 traffic series after NIC fetch failure, got %d", count)
+	}
+}
+
 func TestVNetCollector_Describe(t *testing.T) {
 	config := DefaultMockConfig()
 

--- a/tests/vnet_test.go
+++ b/tests/vnet_test.go
@@ -1,0 +1,191 @@
+package tests
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"vergeos-exporter/collectors"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// newVNetMockServer builds a mock server serving /vnets and
+// /vnet_monitor_stats_history_short (filtered by "vnet eq <id>").
+func newVNetMockServer(t *testing.T, config MockServerConfig, clusters []ClusterMock, vnets []VNetMock, stats []VNetMonitorStatsMock) *httptest.Server {
+	return NewBaseMockServer(t, config, func(w http.ResponseWriter, r *http.Request) bool {
+		switch {
+		case strings.Contains(r.URL.Path, "/clusters"):
+			WriteJSONResponse(w, clusters)
+			return true
+		case strings.Contains(r.URL.Path, "/vnet_monitor_stats_history_short"):
+			filter := r.URL.Query().Get("filter")
+			matched := []VNetMonitorStatsMock{}
+			for _, s := range stats {
+				if filter == fmt.Sprintf("vnet eq %d", s.VNet) {
+					matched = append(matched, s)
+				}
+			}
+			WriteJSONResponse(w, matched)
+			return true
+		case strings.Contains(r.URL.Path, "/vnets"):
+			WriteJSONResponse(w, vnets)
+			return true
+		}
+		return false
+	})
+}
+
+func TestVNetCollector_Metrics(t *testing.T) {
+	config := DefaultMockConfig()
+	config.CloudName = "test-cloud"
+
+	clusters := []ClusterMock{
+		{Key: 1, Name: "cluster1", Enabled: true},
+	}
+
+	vnets := []VNetMock{
+		// External network with gateway monitoring and stats available
+		{Key: 10, Name: "external", Enabled: true, PowerState: true, Cluster: 1,
+			Type: "external", Layer2Type: "", MonitorGateway: true},
+		// Internal network, no monitoring
+		{Key: 11, Name: "internal", Enabled: true, PowerState: false, Cluster: 1,
+			Type: "internal", Layer2Type: "vxlan", MonitorGateway: false},
+		// Monitoring enabled but no stats row yet
+		{Key: 12, Name: "newnet", Enabled: false, PowerState: false, Cluster: 1,
+			Type: "internal", Layer2Type: "vlan", MonitorGateway: true},
+	}
+
+	stats := []VNetMonitorStatsMock{
+		{Key: 1, VNet: 10, Sent: 100, Quality: 98, DroppedPct: 2,
+			LatencyUSAvg: 1500, LatencyUSPeak: 9000, Duplicates: 1, Truncated: 2,
+			Dropped: 3, BadChecksums: 4, BadData: 5, Timestamp: 1700000000},
+	}
+
+	mockServer := newVNetMockServer(t, config, clusters, vnets, stats)
+	defer mockServer.Close()
+
+	client := CreateTestSDKClient(t, mockServer.URL)
+	collector := collectors.NewVNetCollector(client, TestScrapeTimeout)
+
+	t.Run("enabled", func(t *testing.T) {
+		expected := `
+			# HELP vergeos_vnet_enabled Whether the virtual network is enabled (1=enabled, 0=disabled)
+			# TYPE vergeos_vnet_enabled gauge
+			vergeos_vnet_enabled{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1
+			vergeos_vnet_enabled{cluster="cluster1",layer2_type="vxlan",system_name="test-cloud",type="internal",vnet_id="11",vnet_name="internal"} 1
+			vergeos_vnet_enabled{cluster="cluster1",layer2_type="vlan",system_name="test-cloud",type="internal",vnet_id="12",vnet_name="newnet"} 0
+		`
+		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vnet_enabled"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("powerstate", func(t *testing.T) {
+		expected := `
+			# HELP vergeos_vnet_powerstate Whether the virtual network is running (1=running, 0=stopped)
+			# TYPE vergeos_vnet_powerstate gauge
+			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1
+			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="vxlan",system_name="test-cloud",type="internal",vnet_id="11",vnet_name="internal"} 0
+			vergeos_vnet_powerstate{cluster="cluster1",layer2_type="vlan",system_name="test-cloud",type="internal",vnet_id="12",vnet_name="newnet"} 0
+		`
+		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vnet_powerstate"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("monitor_gateway", func(t *testing.T) {
+		expected := `
+			# HELP vergeos_vnet_monitor_gateway Whether gateway monitoring is enabled for the virtual network (1=enabled, 0=disabled)
+			# TYPE vergeos_vnet_monitor_gateway gauge
+			vergeos_vnet_monitor_gateway{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1
+			vergeos_vnet_monitor_gateway{cluster="cluster1",layer2_type="vxlan",system_name="test-cloud",type="internal",vnet_id="11",vnet_name="internal"} 0
+			vergeos_vnet_monitor_gateway{cluster="cluster1",layer2_type="vlan",system_name="test-cloud",type="internal",vnet_id="12",vnet_name="newnet"} 1
+		`
+		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vnet_monitor_gateway"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("monitor_stats", func(t *testing.T) {
+		// Only vnet 10 has a stats row; vnet 12 has monitoring enabled but no
+		// stats yet and must not emit monitor series or fail the scrape.
+		expected := `
+			# HELP vergeos_vnet_monitor_quality Gateway network quality percentage (100 - dropped_pct) from the latest sample
+			# TYPE vergeos_vnet_monitor_quality gauge
+			vergeos_vnet_monitor_quality{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 98
+			# HELP vergeos_vnet_monitor_latency_usec_avg Average gateway latency in microseconds from the latest sample
+			# TYPE vergeos_vnet_monitor_latency_usec_avg gauge
+			vergeos_vnet_monitor_latency_usec_avg{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1500
+			# HELP vergeos_vnet_monitor_latency_usec_peak Peak gateway latency in microseconds from the latest sample
+			# TYPE vergeos_vnet_monitor_latency_usec_peak gauge
+			vergeos_vnet_monitor_latency_usec_peak{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 9000
+			# HELP vergeos_vnet_monitor_dropped_pct Percentage of dropped monitoring packets in the latest sample
+			# TYPE vergeos_vnet_monitor_dropped_pct gauge
+			vergeos_vnet_monitor_dropped_pct{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 2
+			# HELP vergeos_vnet_monitor_sent Monitoring packets sent in the latest gateway-monitoring sample
+			# TYPE vergeos_vnet_monitor_sent gauge
+			vergeos_vnet_monitor_sent{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 100
+			# HELP vergeos_vnet_monitor_duplicates Duplicate monitoring packets in the latest sample
+			# TYPE vergeos_vnet_monitor_duplicates gauge
+			vergeos_vnet_monitor_duplicates{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1
+			# HELP vergeos_vnet_monitor_truncated Truncated monitoring packets in the latest sample
+			# TYPE vergeos_vnet_monitor_truncated gauge
+			vergeos_vnet_monitor_truncated{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 2
+			# HELP vergeos_vnet_monitor_dropped Dropped monitoring packets in the latest sample
+			# TYPE vergeos_vnet_monitor_dropped gauge
+			vergeos_vnet_monitor_dropped{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 3
+			# HELP vergeos_vnet_monitor_bad_checksums Monitoring packets with bad checksums in the latest sample
+			# TYPE vergeos_vnet_monitor_bad_checksums gauge
+			vergeos_vnet_monitor_bad_checksums{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 4
+			# HELP vergeos_vnet_monitor_bad_data Monitoring packets with bad data in the latest sample
+			# TYPE vergeos_vnet_monitor_bad_data gauge
+			vergeos_vnet_monitor_bad_data{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 5
+			# HELP vergeos_vnet_monitor_timestamp_seconds Unix timestamp of the latest gateway-monitoring sample
+			# TYPE vergeos_vnet_monitor_timestamp_seconds gauge
+			vergeos_vnet_monitor_timestamp_seconds{cluster="cluster1",layer2_type="",system_name="test-cloud",type="external",vnet_id="10",vnet_name="external"} 1.7e+09
+		`
+		metricNames := []string{
+			"vergeos_vnet_monitor_sent",
+			"vergeos_vnet_monitor_quality",
+			"vergeos_vnet_monitor_dropped_pct",
+			"vergeos_vnet_monitor_latency_usec_avg",
+			"vergeos_vnet_monitor_latency_usec_peak",
+			"vergeos_vnet_monitor_duplicates",
+			"vergeos_vnet_monitor_truncated",
+			"vergeos_vnet_monitor_dropped",
+			"vergeos_vnet_monitor_bad_checksums",
+			"vergeos_vnet_monitor_bad_data",
+			"vergeos_vnet_monitor_timestamp_seconds",
+		}
+		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), metricNames...); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+}
+
+func TestVNetCollector_Describe(t *testing.T) {
+	config := DefaultMockConfig()
+
+	mockServer := NewBaseMockServer(t, config, nil)
+	defer mockServer.Close()
+
+	client := CreateTestSDKClient(t, mockServer.URL)
+	collector := collectors.NewVNetCollector(client, TestScrapeTimeout)
+
+	ch := make(chan *prometheus.Desc, 20)
+	collector.Describe(ch)
+	close(ch)
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	if count != 14 {
+		t.Errorf("Expected 14 descriptors, got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #52

Adds a new `VNetCollector` that exposes virtual-network metrics alongside the existing physical NIC and VM NIC metrics, using `Networks.List`, `Networks.GetLatestStatistics`, and `MachineNICs.List` from govergeos v0.3.0.

## Changes

- `collectors/vnet.go` — new collector, all metrics labeled `system_name`, `vnet_name`, `vnet_id`, `cluster`, `type`, `layer2_type`:
  - Inventory gauges: `vergeos_vnet_enabled`, `vergeos_vnet_powerstate` (from `machine#status#running` — the `/vnets` `powerstate` DB field is unmaintained and reads false for running networks), `vergeos_vnet_monitor_gateway`
  - Router NIC traffic counters: `vergeos_vnet_{tx,rx}_{bytes,packets}_total` (primary router NIC, joined against the bulk `machine_nics` fetch)
  - Latest gateway-monitoring stats for monitored networks: sent, quality, dropped_pct, latency avg/peak, duplicates, truncated, dropped, bad checksums/data, sample timestamp
- Networks with monitoring enabled but no stats row yet are skipped without failing the scrape; a per-network stats error logs and continues.
- `go.mod`/`go.sum` — govergeos bumped to published v0.3.0, local `replace` removed.
- `main.go` — register the collector.
- `tests/vnet_test.go` + mock types — covers `/vnets`, `/machine_nics` join, latest `/vnet_monitor_stats_history_short`, and the monitoring-enabled-but-no-stats case.
- `metrics.md`, `README.md`, `CLAUDE.md` — docs.

One deliberate deviation from the issue: monitor stats are exposed as **gauges without `_total` suffixes**, not counters. The `vnet_monitor_stats_history_short` rows are per-interval samples (uint16 fields, rows expire), not cumulative counters — naming them `_total` would invite broken `rate()` queries.

## Test Plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./...` passes (new `TestVNetCollector_*` tests included)
- [x] Verified against a live VergeOS 26.x system: powerstate matches the UI (7 running / 6 stopped), traffic counters flowing, monitor stats only for the monitored network