### PR TITLE
feat: add API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ go build -o vergeos-exporter
 - `-web.listen-address`: Address to listen on for web interface and telemetry (default: ":9888")
 - `-web.telemetry-path`: Path under which to expose metrics
 - `-verge.url`: VergeOS API URL (default: "https://localhost"). Also: `VERGE_URL` env var
-- `-verge.username`: VergeOS API username (required). Also: `VERGE_USERNAME` env var
-- `-verge.password`: VergeOS API password (required). Also: `VERGE_PASSWORD` env var
+- `-verge.username`: VergeOS API username (required with password unless using an API key). Also: `VERGE_USERNAME` env var
+- `-verge.password`: VergeOS API password (required with username unless using an API key). Also: `VERGE_PASSWORD` env var
+- `-verge.apikey`: VergeOS API key (alternative to username/password). Also: `VERGE_API_KEY` env var
 - `-scrape.timeout`: Timeout for scraping VergeOS API (default: 30s)
 
 Environment variables are recommended over CLI flags in production to avoid exposing credentials in the process list.
@@ -103,6 +104,9 @@ Environment variables are recommended over CLI flags in production to avoid expo
 
 ```bash
 ./vergeos-exporter -verge.url="https://VERGEURL" -verge.username="admin" -verge.password="password"
+
+# Or authenticate with an API key
+./vergeos-exporter -verge.url="https://VERGEURL" -verge.apikey="API_KEY"
 ```
 
 ### Permissions
@@ -208,7 +212,7 @@ cd "C:\Program Files\vergeos-exporter"
   -verge.password="PASSWORD" `
   -log.file="C:\Program Files\vergeos-exporter\logs\exporter.log"
 ```
-   The service is created with automatic startup, so it will launch on boot. Use `-log.file` to capture logs, since a Windows service has no console. Credentials can also be supplied via the `VERGE_URL`, `VERGE_USERNAME`, and `VERGE_PASSWORD` environment variables instead of flags.
+   The service is created with automatic startup, so it will launch on boot. Use `-log.file` to capture logs, since a Windows service has no console. Credentials can also be supplied via the `VERGE_URL`, `VERGE_USERNAME`, `VERGE_PASSWORD`, and `VERGE_API_KEY` environment variables instead of flags.
 
 3. Start the service:
 ```powershell

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	vergeURL      = flag.String("verge.url", "http://localhost", "Base URL of the VergeOS API")
 	vergeUsername = flag.String("verge.username", "", "Username for VergeOS API authentication")
 	vergePassword = flag.String("verge.password", "", "Password for VergeOS API authentication")
+	vergeAPIKey   = flag.String("verge.apikey", "", "API key for VergeOS API authentication (alternative to username/password)")
 	scrapeTimeout = flag.Duration("scrape.timeout", 30*time.Second, "Timeout for scraping VergeOS API")
 	insecure      = flag.Bool("insecure", false, "Skip TLS certificate verification (use for self-signed certificates)")
 	logFile       = flag.String("log.file", "", "Write logs to this file instead of stderr (useful when running as a service).")
@@ -64,6 +65,9 @@ func main() {
 	if *vergePassword == "" {
 		*vergePassword = os.Getenv("VERGE_PASSWORD")
 	}
+	if *vergeAPIKey == "" {
+		*vergeAPIKey = os.Getenv("VERGE_API_KEY")
+	}
 
 	// Windows service control/hosting. On non-Windows platforms this is a no-op
 	// unless -service was passed, in which case it reports a clear error.
@@ -85,8 +89,9 @@ func main() {
 // platform-neutral: main() calls it directly for foreground runs, and the
 // Windows service handler calls it with a stop channel driven by the SCM.
 func runExporter(stop <-chan struct{}) error {
-	if *vergeUsername == "" || *vergePassword == "" {
-		return fmt.Errorf("verge.username and verge.password are required (flags or VERGE_USERNAME/VERGE_PASSWORD env vars)")
+	auth, err := authOption(*vergeAPIKey, *vergeUsername, *vergePassword)
+	if err != nil {
+		return err
 	}
 
 	if *insecure {
@@ -96,7 +101,7 @@ func runExporter(stop <-chan struct{}) error {
 	// Create SDK client for API operations
 	client, err := vergeos.NewClient(
 		vergeos.WithBaseURL(*vergeURL),
-		vergeos.WithCredentials(*vergeUsername, *vergePassword),
+		auth,
 		vergeos.WithInsecureTLS(*insecure),
 		vergeos.WithTimeout(*scrapeTimeout),
 	)
@@ -111,7 +116,7 @@ func runExporter(stop <-chan struct{}) error {
 	cloudName, err := client.Settings.GetCloudName(ctx)
 	if err != nil {
 		if vergeos.IsAuthError(err) {
-			return fmt.Errorf("authentication failed: check username/password for %s", *vergeURL)
+			return fmt.Errorf("authentication failed: check API key or username/password for %s", *vergeURL)
 		}
 		return fmt.Errorf("failed to connect to VergeOS API at %s: %w", *vergeURL, err)
 	}
@@ -183,4 +188,14 @@ func runExporter(stop <-chan struct{}) error {
 		return fmt.Errorf("server error: %w", err)
 	}
 	return nil
+}
+
+func authOption(apiKey, username, password string) (vergeos.ClientOption, error) {
+	if apiKey != "" {
+		return vergeos.WithAPIKey(apiKey), nil
+	}
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("authentication required: provide verge.apikey (or VERGE_API_KEY) or both verge.username and verge.password (or VERGE_USERNAME/VERGE_PASSWORD)")
+	}
+	return vergeos.WithCredentials(username, password), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	vergeos "github.com/verge-io/govergeos"
+)
+
+func TestAuthOptionUsesAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"26.0.0"}`)
+	}))
+	defer server.Close()
+
+	auth, err := authOption("test-key", "ignored-user", "ignored-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vergeos.NewClient(vergeos.WithBaseURL(server.URL), auth); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := authOption("", "user", ""); err == nil {
+		t.Fatal("expected incomplete username/password to fail")
+	}
+}


### PR DESCRIPTION
## Summary

- add `-verge.apikey` and `VERGE_API_KEY` configuration
- use the SDK's Bearer-token authentication when an API key is provided while preserving username/password authentication
- document API-key usage and add regression coverage for auth selection

## Root cause

The pinned `govergeos` SDK already supported `WithAPIKey`, but the exporter required username/password and always constructed the client with `WithCredentials`.

## Impact

Operators can authenticate the exporter with a VergeOS API key without exposing or maintaining a user password. Existing Basic authentication remains unchanged.

## Validation

- `go test ./...`
- `go build ./...`
- Windows amd64 cross-build
- live API-key-only exporter scrape returned HTTP 200 with VergeOS metrics

Closes #48