### PR TITLE
fix: report detailed CPU metrics only for physical nodes

### DIFF
--- a/collectors/node.go
+++ b/collectors/node.go
@@ -24,6 +24,10 @@ type NodeCollector struct {
 	nodeRAM        *prometheus.Desc
 
 	// MachineStats metrics (Issue 1)
+	nodeCPUTotal     *prometheus.Desc
+	nodeCPUUser      *prometheus.Desc
+	nodeCPUSystem    *prometheus.Desc
+	nodeCPUIowait    *prometheus.Desc
 	nodeCPUCoreUsage *prometheus.Desc
 	nodeCoreTemp     *prometheus.Desc
 	nodeRAMUsed      *prometheus.Desc
@@ -61,6 +65,30 @@ func NewNodeCollector(client *vergeos.Client, scrapeTimeout time.Duration) *Node
 		nodeRAM: prometheus.NewDesc(
 			"vergeos_node_ram_allocated",
 			"VM RAM in MB (vm_ram field)",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUTotal: prometheus.NewDesc(
+			"vergeos_node_cpu_total",
+			"Total CPU usage percentage",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUUser: prometheus.NewDesc(
+			"vergeos_node_cpu_user",
+			"User CPU usage percentage",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUSystem: prometheus.NewDesc(
+			"vergeos_node_cpu_system",
+			"System CPU usage percentage",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUIowait: prometheus.NewDesc(
+			"vergeos_node_cpu_iowait",
+			"IO Wait CPU usage percentage",
 			nodeLabels,
 			nil,
 		),
@@ -111,6 +139,10 @@ func (nc *NodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- nc.nodeIPMIStatus
 	ch <- nc.nodeRAMTotal
 	ch <- nc.nodeRAM
+	ch <- nc.nodeCPUTotal
+	ch <- nc.nodeCPUUser
+	ch <- nc.nodeCPUSystem
+	ch <- nc.nodeCPUIowait
 	ch <- nc.nodeCPUCoreUsage
 	ch <- nc.nodeCoreTemp
 	ch <- nc.nodeRAMUsed
@@ -223,6 +255,11 @@ func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
 		if !ok {
 			continue
 		}
+
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUTotal, prometheus.GaugeValue, float64(stats.TotalCPU), systemName, clusterName, node.Name)
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUUser, prometheus.GaugeValue, float64(stats.UserCPU), systemName, clusterName, node.Name)
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUSystem, prometheus.GaugeValue, float64(stats.SystemCPU), systemName, clusterName, node.Name)
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUIowait, prometheus.GaugeValue, float64(stats.IOWaitCPU), systemName, clusterName, node.Name)
 
 		// Per-core CPU usage
 		coreUsages, err := stats.GetCoreUsages()

--- a/collectors/vm.go
+++ b/collectors/vm.go
@@ -25,10 +25,7 @@ type VMCollector struct {
 	mutex sync.Mutex
 
 	// CPU metrics
-	vmCPUTotal  *prometheus.Desc
-	vmCPUUser   *prometheus.Desc
-	vmCPUSystem *prometheus.Desc
-	vmCPUIowait *prometheus.Desc
+	vmCPUTotal *prometheus.Desc
 
 	// State metrics
 	vmRunning *prometheus.Desc
@@ -68,24 +65,6 @@ func NewVMCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VMColl
 		vmCPUTotal: prometheus.NewDesc(
 			"vergeos_vm_cpu_total",
 			"Total CPU usage percentage",
-			vmLabels,
-			nil,
-		),
-		vmCPUUser: prometheus.NewDesc(
-			"vergeos_vm_cpu_user",
-			"User CPU usage percentage",
-			vmLabels,
-			nil,
-		),
-		vmCPUSystem: prometheus.NewDesc(
-			"vergeos_vm_cpu_system",
-			"System CPU usage percentage",
-			vmLabels,
-			nil,
-		),
-		vmCPUIowait: prometheus.NewDesc(
-			"vergeos_vm_cpu_iowait",
-			"IO Wait CPU usage percentage",
 			vmLabels,
 			nil,
 		),
@@ -191,9 +170,6 @@ func NewVMCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VMColl
 // Describe implements prometheus.Collector
 func (vc *VMCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- vc.vmCPUTotal
-	ch <- vc.vmCPUUser
-	ch <- vc.vmCPUSystem
-	ch <- vc.vmCPUIowait
 	ch <- vc.vmRunning
 	ch <- vc.vmEnabled
 	ch <- vc.vmCPUCores
@@ -298,18 +274,12 @@ func (vc *VMCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(vc.vmRAMBytes, prometheus.GaugeValue, float64(vm.RAM)*1048576, labels...)
 
 		// CPU stats (0 if powered off or no stats available)
-		var totalCPU, userCPU, systemCPU, iowaitCPU float64
+		var totalCPU float64
 		if stats, ok := statsMap[vm.Machine]; ok {
 			totalCPU = float64(stats.TotalCPU)
-			userCPU = float64(stats.UserCPU)
-			systemCPU = float64(stats.SystemCPU)
-			iowaitCPU = float64(stats.IOWaitCPU)
 		}
 
 		ch <- prometheus.MustNewConstMetric(vc.vmCPUTotal, prometheus.GaugeValue, totalCPU, labels...)
-		ch <- prometheus.MustNewConstMetric(vc.vmCPUUser, prometheus.GaugeValue, userCPU, labels...)
-		ch <- prometheus.MustNewConstMetric(vc.vmCPUSystem, prometheus.GaugeValue, systemCPU, labels...)
-		ch <- prometheus.MustNewConstMetric(vc.vmCPUIowait, prometheus.GaugeValue, iowaitCPU, labels...)
 
 		// NIC metrics (only for VMs with NICs)
 		if nics, ok := nicMap[vm.Machine]; ok {

--- a/metrics.md
+++ b/metrics.md
@@ -8,6 +8,10 @@
 ## Node Details and Stats
 
 ### CPU Metrics
+- **Total CPU Usage**: `vergeos_node_cpu_total` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
+- **User CPU Usage**: `vergeos_node_cpu_user` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
+- **System CPU Usage**: `vergeos_node_cpu_system` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
+- **IO Wait CPU Usage**: `vergeos_node_cpu_iowait` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
 - **CPU Usage per Core**: `vergeos_node_cpu_core_usage` (Gauge, labeled by `system_name`, `cluster`, `node_name`, and `core_id`)
 - **CPU Temperature**: `vergeos_node_core_temp` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
 - **Running Cores**: `vergeos_node_running_cores` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
@@ -185,11 +189,8 @@ All VM metrics include labels: `system_name`, `cluster`, `node`, `vm_name`, `vm_
 
 ### VM CPU Metrics
 - **Total CPU Usage**: `vergeos_vm_cpu_total` (Gauge, percentage 0-100)
-- **User CPU Usage**: `vergeos_vm_cpu_user` (Gauge, percentage 0-100)
-- **System CPU Usage**: `vergeos_vm_cpu_system` (Gauge, percentage 0-100)
-- **IO Wait CPU Usage**: `vergeos_vm_cpu_iowait` (Gauge, percentage 0-100)
 
-Powered-off VMs report 0 for all CPU metrics.
+Powered-off VMs report 0 CPU usage.
 
 ### VM NIC Metrics
 Additional label: `nic_name`. Only emitted for VMs with NIC stats available.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -79,6 +79,23 @@ func TestIntegrationNodeCollector(t *testing.T) {
 
 	metrics := collectMetrics(t, nc)
 
+	t.Run("cpu_breakdown", func(t *testing.T) {
+		for _, name := range []string{
+			"vergeos_node_cpu_total",
+			"vergeos_node_cpu_user",
+			"vergeos_node_cpu_system",
+			"vergeos_node_cpu_iowait",
+		} {
+			found := filterMetrics(metrics, name)
+			if len(found) == 0 {
+				t.Errorf("Expected at least one %s metric", name)
+			}
+			for _, m := range found {
+				assertHasLabels(t, m, "system_name", "cluster", "node_name")
+			}
+		}
+	})
+
 	t.Run("running_cores", func(t *testing.T) {
 		found := filterMetrics(metrics, "vergeos_node_running_cores")
 		if len(found) == 0 {
@@ -202,33 +219,15 @@ func TestIntegrationVMCollector(t *testing.T) {
 		t.Logf("Found %d VM CPU total metrics", len(found))
 	})
 
-	t.Run("vm_cpu_user", func(t *testing.T) {
-		found := filterMetrics(metrics, "vergeos_vm_cpu_user")
-		if len(found) == 0 {
-			t.Fatal("Expected at least one vergeos_vm_cpu_user metric")
-		}
-		for _, m := range found {
-			assertHasLabels(t, m, "system_name", "cluster", "node", "vm_name", "vm_id")
-		}
-	})
-
-	t.Run("vm_cpu_system", func(t *testing.T) {
-		found := filterMetrics(metrics, "vergeos_vm_cpu_system")
-		if len(found) == 0 {
-			t.Fatal("Expected at least one vergeos_vm_cpu_system metric")
-		}
-		for _, m := range found {
-			assertHasLabels(t, m, "system_name", "cluster", "node", "vm_name", "vm_id")
-		}
-	})
-
-	t.Run("vm_cpu_iowait", func(t *testing.T) {
-		found := filterMetrics(metrics, "vergeos_vm_cpu_iowait")
-		if len(found) == 0 {
-			t.Fatal("Expected at least one vergeos_vm_cpu_iowait metric")
-		}
-		for _, m := range found {
-			assertHasLabels(t, m, "system_name", "cluster", "node", "vm_name", "vm_id")
+	t.Run("vm_cpu_breakdown_absent", func(t *testing.T) {
+		for _, name := range []string{
+			"vergeos_vm_cpu_user",
+			"vergeos_vm_cpu_system",
+			"vergeos_vm_cpu_iowait",
+		} {
+			if found := filterMetrics(metrics, name); len(found) != 0 {
+				t.Errorf("Expected %s to be absent, found %d metrics", name, len(found))
+			}
 		}
 	})
 

--- a/tests/node_test.go
+++ b/tests/node_test.go
@@ -27,8 +27,8 @@ func TestNodeCollector(t *testing.T) {
 	}
 
 	machineStats := map[int]MachineStatsMock{
-		101: {Key: 1, Machine: 101, TotalCPU: 45, RAMUsed: 48000, RAMPct: 73, CoreUsageList: json.RawMessage(`[10.5, 20.3, 30.1, 40.0]`), CoreTemp: 55, CoreTempTop: 62},
-		102: {Key: 2, Machine: 102, TotalCPU: 30, RAMUsed: 32000, RAMPct: 49, CoreUsageList: json.RawMessage(`[5.0, 15.0]`), CoreTemp: 42, CoreTempTop: 48},
+		101: {Key: 1, Machine: 101, TotalCPU: 45, UserCPU: 20, SystemCPU: 15, IOWaitCPU: 10, RAMUsed: 48000, RAMPct: 73, CoreUsageList: json.RawMessage(`[10.5, 20.3, 30.1, 40.0]`), CoreTemp: 55, CoreTempTop: 62},
+		102: {Key: 2, Machine: 102, TotalCPU: 30, UserCPU: 10, SystemCPU: 15, IOWaitCPU: 5, RAMUsed: 32000, RAMPct: 49, CoreUsageList: json.RawMessage(`[5.0, 15.0]`), CoreTemp: 42, CoreTempTop: 48},
 	}
 
 	mockServer := NewBaseMockServer(t, config, func(w http.ResponseWriter, r *http.Request) bool {
@@ -81,6 +81,10 @@ func TestNodeCollector(t *testing.T) {
 		"vergeos_node_ipmi_status":    false,
 		"vergeos_node_ram_total":      false,
 		"vergeos_node_ram_allocated":  false,
+		"vergeos_node_cpu_total":      false,
+		"vergeos_node_cpu_user":       false,
+		"vergeos_node_cpu_system":     false,
+		"vergeos_node_cpu_iowait":     false,
 		"vergeos_node_cpu_core_usage": false,
 		"vergeos_node_core_temp":      false,
 		"vergeos_node_ram_used":       false,
@@ -144,6 +148,37 @@ func TestNodeCollector(t *testing.T) {
 			vergeos_node_ram_allocated{cluster="cluster1",node_name="node2",system_name="testcloud"} 16384
 		`
 		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_node_ram_allocated"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("cpu_breakdown", func(t *testing.T) {
+		expected := `
+			# HELP vergeos_node_cpu_total Total CPU usage percentage
+			# TYPE vergeos_node_cpu_total gauge
+			vergeos_node_cpu_total{cluster="cluster1",node_name="node1",system_name="testcloud"} 45
+			vergeos_node_cpu_total{cluster="cluster1",node_name="node2",system_name="testcloud"} 30
+			# HELP vergeos_node_cpu_user User CPU usage percentage
+			# TYPE vergeos_node_cpu_user gauge
+			vergeos_node_cpu_user{cluster="cluster1",node_name="node1",system_name="testcloud"} 20
+			vergeos_node_cpu_user{cluster="cluster1",node_name="node2",system_name="testcloud"} 10
+			# HELP vergeos_node_cpu_system System CPU usage percentage
+			# TYPE vergeos_node_cpu_system gauge
+			vergeos_node_cpu_system{cluster="cluster1",node_name="node1",system_name="testcloud"} 15
+			vergeos_node_cpu_system{cluster="cluster1",node_name="node2",system_name="testcloud"} 15
+			# HELP vergeos_node_cpu_iowait IO Wait CPU usage percentage
+			# TYPE vergeos_node_cpu_iowait gauge
+			vergeos_node_cpu_iowait{cluster="cluster1",node_name="node1",system_name="testcloud"} 10
+			vergeos_node_cpu_iowait{cluster="cluster1",node_name="node2",system_name="testcloud"} 5
+		`
+		if err := testutil.CollectAndCompare(
+			collector,
+			strings.NewReader(expected),
+			"vergeos_node_cpu_total",
+			"vergeos_node_cpu_user",
+			"vergeos_node_cpu_system",
+			"vergeos_node_cpu_iowait",
+		); err != nil {
 			t.Errorf("Unexpected metric values: %v", err)
 		}
 	})

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -27,7 +27,7 @@ func TestVMCollector(t *testing.T) {
 	}
 
 	allMachineStats := []MachineStatsMock{
-		{Key: 1, Machine: 101, TotalCPU: 75, UserCPU: 50, SystemCPU: 20, IOWaitCPU: 5},
+		{Key: 1, Machine: 101, TotalCPU: 75},
 	}
 
 	allMachineStatuses := []MachineStatusMock{
@@ -111,9 +111,6 @@ func TestVMCollector(t *testing.T) {
 	// Verify all expected metrics exist
 	expectedMetrics := map[string]bool{
 		"vergeos_vm_cpu_total":              false,
-		"vergeos_vm_cpu_user":               false,
-		"vergeos_vm_cpu_system":             false,
-		"vergeos_vm_cpu_iowait":             false,
 		"vergeos_vm_running":                false,
 		"vergeos_vm_enabled":                false,
 		"vergeos_vm_cpu_cores":              false,
@@ -141,6 +138,17 @@ func TestVMCollector(t *testing.T) {
 	for metric, found := range expectedMetrics {
 		if !found {
 			t.Errorf("Expected metric %s not found", metric)
+		}
+	}
+
+	removedMetrics := map[string]bool{
+		"vergeos_vm_cpu_user":   true,
+		"vergeos_vm_cpu_system": true,
+		"vergeos_vm_cpu_iowait": true,
+	}
+	for _, mf := range metrics {
+		if removedMetrics[mf.GetName()] {
+			t.Errorf("Removed metric %s is still exposed", mf.GetName())
 		}
 	}
 
@@ -319,7 +327,7 @@ func TestVMCollector_SnapshotFiltering(t *testing.T) {
 
 		case strings.Contains(r.URL.Path, "/machine_stats"):
 			WriteJSONResponse(w, []MachineStatsMock{
-				{Key: 1, Machine: 101, TotalCPU: 30, UserCPU: 20, SystemCPU: 8, IOWaitCPU: 2},
+				{Key: 1, Machine: 101, TotalCPU: 30},
 			})
 			return true
 
@@ -389,7 +397,7 @@ func TestVMCollector_StaleMetrics(t *testing.T) {
 			var stats []MachineStatsMock
 			for i := 1; i <= vmCount; i++ {
 				stats = append(stats, MachineStatsMock{
-					Key: i, Machine: 100 + i, TotalCPU: 50, UserCPU: 30, SystemCPU: 15, IOWaitCPU: 5,
+					Key: i, Machine: 100 + i, TotalCPU: 50,
 				})
 			}
 			WriteJSONResponse(w, stats)


### PR DESCRIPTION
## Summary

- remove the always-zero VM user, system, and I/O-wait CPU metric families
- expose total, user, system, and I/O-wait CPU usage for physical nodes
- update focused unit/integration tests and the metric reference

## Root cause

`machine_stats` contains fields shared by multiple machine types. The VM collector treated host-only CPU breakdown fields as guest statistics, while the physical-node collector did not expose the fields VergeOS actually populates.

The fix reuses the node collector's existing physical-node list and batched `MachineStats.List` result; it adds no API calls.

## Impact

`vergeos_vm_cpu_total` remains available. These misleading VM metric families are removed:

- `vergeos_vm_cpu_user`
- `vergeos_vm_cpu_system`
- `vergeos_vm_cpu_iowait`

Physical nodes now expose:

- `vergeos_node_cpu_total`
- `vergeos_node_cpu_user`
- `vergeos_node_cpu_system`
- `vergeos_node_cpu_iowait`

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -tags=integration ./tests -run 'TestIntegration(Node|VM)Collector' -count=1 -v`
- ran the exporter against the VergeOS system configured in `.env`
- confirmed all four node CPU metric values matched the immediate live `/machine_stats` API response for every physical node
- confirmed the three removed VM metric families were absent from the live scrape

Fixes #47
