### PR TITLE
release: v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ go build -o vergeos-exporter
 - `-web.listen-address`: Address to listen on for web interface and telemetry (default: ":9888")
 - `-web.telemetry-path`: Path under which to expose metrics
 - `-verge.url`: VergeOS API URL (default: "https://localhost"). Also: `VERGE_URL` env var
-- `-verge.username`: VergeOS API username (required). Also: `VERGE_USERNAME` env var
-- `-verge.password`: VergeOS API password (required). Also: `VERGE_PASSWORD` env var
+- `-verge.username`: VergeOS API username (required with password unless using an API key). Also: `VERGE_USERNAME` env var
+- `-verge.password`: VergeOS API password (required with username unless using an API key). Also: `VERGE_PASSWORD` env var
+- `-verge.apikey`: VergeOS API key (alternative to username/password). Also: `VERGE_API_KEY` env var
 - `-scrape.timeout`: Timeout for scraping VergeOS API (default: 30s)
 
 Environment variables are recommended over CLI flags in production to avoid exposing credentials in the process list.
@@ -103,6 +104,9 @@ Environment variables are recommended over CLI flags in production to avoid expo
 
 ```bash
 ./vergeos-exporter -verge.url="https://VERGEURL" -verge.username="admin" -verge.password="password"
+
+# Or authenticate with an API key
+./vergeos-exporter -verge.url="https://VERGEURL" -verge.apikey="API_KEY"
 ```
 
 ### Permissions
@@ -208,7 +212,7 @@ cd "C:\Program Files\vergeos-exporter"
   -verge.password="PASSWORD" `
   -log.file="C:\Program Files\vergeos-exporter\logs\exporter.log"
 ```
-   The service is created with automatic startup, so it will launch on boot. Use `-log.file` to capture logs, since a Windows service has no console. Credentials can also be supplied via the `VERGE_URL`, `VERGE_USERNAME`, and `VERGE_PASSWORD` environment variables instead of flags.
+   The service is created with automatic startup, so it will launch on boot. Use `-log.file` to capture logs, since a Windows service has no console. Credentials can also be supplied via the `VERGE_URL`, `VERGE_USERNAME`, `VERGE_PASSWORD`, and `VERGE_API_KEY` environment variables instead of flags.
 
 3. Start the service:
 ```powershell

--- a/collectors/node.go
+++ b/collectors/node.go
@@ -24,6 +24,10 @@ type NodeCollector struct {
 	nodeRAM        *prometheus.Desc
 
 	// MachineStats metrics (Issue 1)
+	nodeCPUTotal     *prometheus.Desc
+	nodeCPUUser      *prometheus.Desc
+	nodeCPUSystem    *prometheus.Desc
+	nodeCPUIowait    *prometheus.Desc
 	nodeCPUCoreUsage *prometheus.Desc
 	nodeCoreTemp     *prometheus.Desc
 	nodeRAMUsed      *prometheus.Desc
@@ -61,6 +65,30 @@ func NewNodeCollector(client *vergeos.Client, scrapeTimeout time.Duration) *Node
 		nodeRAM: prometheus.NewDesc(
 			"vergeos_node_ram_allocated",
 			"VM RAM in MB (vm_ram field)",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUTotal: prometheus.NewDesc(
+			"vergeos_node_cpu_total",
+			"Total CPU usage percentage",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUUser: prometheus.NewDesc(
+			"vergeos_node_cpu_user",
+			"User CPU usage percentage",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUSystem: prometheus.NewDesc(
+			"vergeos_node_cpu_system",
+			"System CPU usage percentage",
+			nodeLabels,
+			nil,
+		),
+		nodeCPUIowait: prometheus.NewDesc(
+			"vergeos_node_cpu_iowait",
+			"IO Wait CPU usage percentage",
 			nodeLabels,
 			nil,
 		),
@@ -111,6 +139,10 @@ func (nc *NodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- nc.nodeIPMIStatus
 	ch <- nc.nodeRAMTotal
 	ch <- nc.nodeRAM
+	ch <- nc.nodeCPUTotal
+	ch <- nc.nodeCPUUser
+	ch <- nc.nodeCPUSystem
+	ch <- nc.nodeCPUIowait
 	ch <- nc.nodeCPUCoreUsage
 	ch <- nc.nodeCoreTemp
 	ch <- nc.nodeRAMUsed
@@ -223,6 +255,11 @@ func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
 		if !ok {
 			continue
 		}
+
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUTotal, prometheus.GaugeValue, float64(stats.TotalCPU), systemName, clusterName, node.Name)
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUUser, prometheus.GaugeValue, float64(stats.UserCPU), systemName, clusterName, node.Name)
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUSystem, prometheus.GaugeValue, float64(stats.SystemCPU), systemName, clusterName, node.Name)
+		ch <- prometheus.MustNewConstMetric(nc.nodeCPUIowait, prometheus.GaugeValue, float64(stats.IOWaitCPU), systemName, clusterName, node.Name)
 
 		// Per-core CPU usage
 		coreUsages, err := stats.GetCoreUsages()

--- a/collectors/vm.go
+++ b/collectors/vm.go
@@ -25,10 +25,7 @@ type VMCollector struct {
 	mutex sync.Mutex
 
 	// CPU metrics
-	vmCPUTotal  *prometheus.Desc
-	vmCPUUser   *prometheus.Desc
-	vmCPUSystem *prometheus.Desc
-	vmCPUIowait *prometheus.Desc
+	vmCPUTotal *prometheus.Desc
 
 	// State metrics
 	vmRunning *prometheus.Desc
@@ -68,24 +65,6 @@ func NewVMCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VMColl
 		vmCPUTotal: prometheus.NewDesc(
 			"vergeos_vm_cpu_total",
 			"Total CPU usage percentage",
-			vmLabels,
-			nil,
-		),
-		vmCPUUser: prometheus.NewDesc(
-			"vergeos_vm_cpu_user",
-			"User CPU usage percentage",
-			vmLabels,
-			nil,
-		),
-		vmCPUSystem: prometheus.NewDesc(
-			"vergeos_vm_cpu_system",
-			"System CPU usage percentage",
-			vmLabels,
-			nil,
-		),
-		vmCPUIowait: prometheus.NewDesc(
-			"vergeos_vm_cpu_iowait",
-			"IO Wait CPU usage percentage",
 			vmLabels,
 			nil,
 		),
@@ -191,9 +170,6 @@ func NewVMCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VMColl
 // Describe implements prometheus.Collector
 func (vc *VMCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- vc.vmCPUTotal
-	ch <- vc.vmCPUUser
-	ch <- vc.vmCPUSystem
-	ch <- vc.vmCPUIowait
 	ch <- vc.vmRunning
 	ch <- vc.vmEnabled
 	ch <- vc.vmCPUCores
@@ -298,18 +274,12 @@ func (vc *VMCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(vc.vmRAMBytes, prometheus.GaugeValue, float64(vm.RAM)*1048576, labels...)
 
 		// CPU stats (0 if powered off or no stats available)
-		var totalCPU, userCPU, systemCPU, iowaitCPU float64
+		var totalCPU float64
 		if stats, ok := statsMap[vm.Machine]; ok {
 			totalCPU = float64(stats.TotalCPU)
-			userCPU = float64(stats.UserCPU)
-			systemCPU = float64(stats.SystemCPU)
-			iowaitCPU = float64(stats.IOWaitCPU)
 		}
 
 		ch <- prometheus.MustNewConstMetric(vc.vmCPUTotal, prometheus.GaugeValue, totalCPU, labels...)
-		ch <- prometheus.MustNewConstMetric(vc.vmCPUUser, prometheus.GaugeValue, userCPU, labels...)
-		ch <- prometheus.MustNewConstMetric(vc.vmCPUSystem, prometheus.GaugeValue, systemCPU, labels...)
-		ch <- prometheus.MustNewConstMetric(vc.vmCPUIowait, prometheus.GaugeValue, iowaitCPU, labels...)
 
 		// NIC metrics (only for VMs with NICs)
 		if nics, ok := nicMap[vm.Machine]; ok {

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	vergeURL      = flag.String("verge.url", "http://localhost", "Base URL of the VergeOS API")
 	vergeUsername = flag.String("verge.username", "", "Username for VergeOS API authentication")
 	vergePassword = flag.String("verge.password", "", "Password for VergeOS API authentication")
+	vergeAPIKey   = flag.String("verge.apikey", "", "API key for VergeOS API authentication (alternative to username/password)")
 	scrapeTimeout = flag.Duration("scrape.timeout", 30*time.Second, "Timeout for scraping VergeOS API")
 	insecure      = flag.Bool("insecure", false, "Skip TLS certificate verification (use for self-signed certificates)")
 	logFile       = flag.String("log.file", "", "Write logs to this file instead of stderr (useful when running as a service).")
@@ -64,6 +65,9 @@ func main() {
 	if *vergePassword == "" {
 		*vergePassword = os.Getenv("VERGE_PASSWORD")
 	}
+	if *vergeAPIKey == "" {
+		*vergeAPIKey = os.Getenv("VERGE_API_KEY")
+	}
 
 	// Windows service control/hosting. On non-Windows platforms this is a no-op
 	// unless -service was passed, in which case it reports a clear error.
@@ -85,8 +89,9 @@ func main() {
 // platform-neutral: main() calls it directly for foreground runs, and the
 // Windows service handler calls it with a stop channel driven by the SCM.
 func runExporter(stop <-chan struct{}) error {
-	if *vergeUsername == "" || *vergePassword == "" {
-		return fmt.Errorf("verge.username and verge.password are required (flags or VERGE_USERNAME/VERGE_PASSWORD env vars)")
+	auth, err := authOption(*vergeAPIKey, *vergeUsername, *vergePassword)
+	if err != nil {
+		return err
 	}
 
 	if *insecure {
@@ -96,7 +101,7 @@ func runExporter(stop <-chan struct{}) error {
 	// Create SDK client for API operations
 	client, err := vergeos.NewClient(
 		vergeos.WithBaseURL(*vergeURL),
-		vergeos.WithCredentials(*vergeUsername, *vergePassword),
+		auth,
 		vergeos.WithInsecureTLS(*insecure),
 		vergeos.WithTimeout(*scrapeTimeout),
 	)
@@ -111,7 +116,7 @@ func runExporter(stop <-chan struct{}) error {
 	cloudName, err := client.Settings.GetCloudName(ctx)
 	if err != nil {
 		if vergeos.IsAuthError(err) {
-			return fmt.Errorf("authentication failed: check username/password for %s", *vergeURL)
+			return fmt.Errorf("authentication failed: check API key or username/password for %s", *vergeURL)
 		}
 		return fmt.Errorf("failed to connect to VergeOS API at %s: %w", *vergeURL, err)
 	}
@@ -183,4 +188,14 @@ func runExporter(stop <-chan struct{}) error {
 		return fmt.Errorf("server error: %w", err)
 	}
 	return nil
+}
+
+func authOption(apiKey, username, password string) (vergeos.ClientOption, error) {
+	if apiKey != "" {
+		return vergeos.WithAPIKey(apiKey), nil
+	}
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("authentication required: provide verge.apikey (or VERGE_API_KEY) or both verge.username and verge.password (or VERGE_USERNAME/VERGE_PASSWORD)")
+	}
+	return vergeos.WithCredentials(username, password), nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	vergeos "github.com/verge-io/govergeos"
+)
+
+func TestAuthOptionUsesAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"26.0.0"}`)
+	}))
+	defer server.Close()
+
+	auth, err := authOption("test-key", "ignored-user", "ignored-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := vergeos.NewClient(vergeos.WithBaseURL(server.URL), auth); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := authOption("", "user", ""); err == nil {
+		t.Fatal("expected incomplete username/password to fail")
+	}
+}

--- a/metrics.md
+++ b/metrics.md
@@ -8,6 +8,10 @@
 ## Node Details and Stats
 
 ### CPU Metrics
+- **Total CPU Usage**: `vergeos_node_cpu_total` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
+- **User CPU Usage**: `vergeos_node_cpu_user` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
+- **System CPU Usage**: `vergeos_node_cpu_system` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
+- **IO Wait CPU Usage**: `vergeos_node_cpu_iowait` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
 - **CPU Usage per Core**: `vergeos_node_cpu_core_usage` (Gauge, labeled by `system_name`, `cluster`, `node_name`, and `core_id`)
 - **CPU Temperature**: `vergeos_node_core_temp` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
 - **Running Cores**: `vergeos_node_running_cores` (Gauge, labeled by `system_name`, `cluster`, and `node_name`)
@@ -185,11 +189,8 @@ All VM metrics include labels: `system_name`, `cluster`, `node`, `vm_name`, `vm_
 
 ### VM CPU Metrics
 - **Total CPU Usage**: `vergeos_vm_cpu_total` (Gauge, percentage 0-100)
-- **User CPU Usage**: `vergeos_vm_cpu_user` (Gauge, percentage 0-100)
-- **System CPU Usage**: `vergeos_vm_cpu_system` (Gauge, percentage 0-100)
-- **IO Wait CPU Usage**: `vergeos_vm_cpu_iowait` (Gauge, percentage 0-100)
 
-Powered-off VMs report 0 for all CPU metrics.
+Powered-off VMs report 0 CPU usage.
 
 ### VM NIC Metrics
 Additional label: `nic_name`. Only emitted for VMs with NIC stats available.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -79,6 +79,23 @@ func TestIntegrationNodeCollector(t *testing.T) {
 
 	metrics := collectMetrics(t, nc)
 
+	t.Run("cpu_breakdown", func(t *testing.T) {
+		for _, name := range []string{
+			"vergeos_node_cpu_total",
+			"vergeos_node_cpu_user",
+			"vergeos_node_cpu_system",
+			"vergeos_node_cpu_iowait",
+		} {
+			found := filterMetrics(metrics, name)
+			if len(found) == 0 {
+				t.Errorf("Expected at least one %s metric", name)
+			}
+			for _, m := range found {
+				assertHasLabels(t, m, "system_name", "cluster", "node_name")
+			}
+		}
+	})
+
 	t.Run("running_cores", func(t *testing.T) {
 		found := filterMetrics(metrics, "vergeos_node_running_cores")
 		if len(found) == 0 {
@@ -202,33 +219,15 @@ func TestIntegrationVMCollector(t *testing.T) {
 		t.Logf("Found %d VM CPU total metrics", len(found))
 	})
 
-	t.Run("vm_cpu_user", func(t *testing.T) {
-		found := filterMetrics(metrics, "vergeos_vm_cpu_user")
-		if len(found) == 0 {
-			t.Fatal("Expected at least one vergeos_vm_cpu_user metric")
-		}
-		for _, m := range found {
-			assertHasLabels(t, m, "system_name", "cluster", "node", "vm_name", "vm_id")
-		}
-	})
-
-	t.Run("vm_cpu_system", func(t *testing.T) {
-		found := filterMetrics(metrics, "vergeos_vm_cpu_system")
-		if len(found) == 0 {
-			t.Fatal("Expected at least one vergeos_vm_cpu_system metric")
-		}
-		for _, m := range found {
-			assertHasLabels(t, m, "system_name", "cluster", "node", "vm_name", "vm_id")
-		}
-	})
-
-	t.Run("vm_cpu_iowait", func(t *testing.T) {
-		found := filterMetrics(metrics, "vergeos_vm_cpu_iowait")
-		if len(found) == 0 {
-			t.Fatal("Expected at least one vergeos_vm_cpu_iowait metric")
-		}
-		for _, m := range found {
-			assertHasLabels(t, m, "system_name", "cluster", "node", "vm_name", "vm_id")
+	t.Run("vm_cpu_breakdown_absent", func(t *testing.T) {
+		for _, name := range []string{
+			"vergeos_vm_cpu_user",
+			"vergeos_vm_cpu_system",
+			"vergeos_vm_cpu_iowait",
+		} {
+			if found := filterMetrics(metrics, name); len(found) != 0 {
+				t.Errorf("Expected %s to be absent, found %d metrics", name, len(found))
+			}
 		}
 	})
 

--- a/tests/node_test.go
+++ b/tests/node_test.go
@@ -27,8 +27,8 @@ func TestNodeCollector(t *testing.T) {
 	}
 
 	machineStats := map[int]MachineStatsMock{
-		101: {Key: 1, Machine: 101, TotalCPU: 45, RAMUsed: 48000, RAMPct: 73, CoreUsageList: json.RawMessage(`[10.5, 20.3, 30.1, 40.0]`), CoreTemp: 55, CoreTempTop: 62},
-		102: {Key: 2, Machine: 102, TotalCPU: 30, RAMUsed: 32000, RAMPct: 49, CoreUsageList: json.RawMessage(`[5.0, 15.0]`), CoreTemp: 42, CoreTempTop: 48},
+		101: {Key: 1, Machine: 101, TotalCPU: 45, UserCPU: 20, SystemCPU: 15, IOWaitCPU: 10, RAMUsed: 48000, RAMPct: 73, CoreUsageList: json.RawMessage(`[10.5, 20.3, 30.1, 40.0]`), CoreTemp: 55, CoreTempTop: 62},
+		102: {Key: 2, Machine: 102, TotalCPU: 30, UserCPU: 10, SystemCPU: 15, IOWaitCPU: 5, RAMUsed: 32000, RAMPct: 49, CoreUsageList: json.RawMessage(`[5.0, 15.0]`), CoreTemp: 42, CoreTempTop: 48},
 	}
 
 	mockServer := NewBaseMockServer(t, config, func(w http.ResponseWriter, r *http.Request) bool {
@@ -81,6 +81,10 @@ func TestNodeCollector(t *testing.T) {
 		"vergeos_node_ipmi_status":    false,
 		"vergeos_node_ram_total":      false,
 		"vergeos_node_ram_allocated":  false,
+		"vergeos_node_cpu_total":      false,
+		"vergeos_node_cpu_user":       false,
+		"vergeos_node_cpu_system":     false,
+		"vergeos_node_cpu_iowait":     false,
 		"vergeos_node_cpu_core_usage": false,
 		"vergeos_node_core_temp":      false,
 		"vergeos_node_ram_used":       false,
@@ -144,6 +148,37 @@ func TestNodeCollector(t *testing.T) {
 			vergeos_node_ram_allocated{cluster="cluster1",node_name="node2",system_name="testcloud"} 16384
 		`
 		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_node_ram_allocated"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("cpu_breakdown", func(t *testing.T) {
+		expected := `
+			# HELP vergeos_node_cpu_total Total CPU usage percentage
+			# TYPE vergeos_node_cpu_total gauge
+			vergeos_node_cpu_total{cluster="cluster1",node_name="node1",system_name="testcloud"} 45
+			vergeos_node_cpu_total{cluster="cluster1",node_name="node2",system_name="testcloud"} 30
+			# HELP vergeos_node_cpu_user User CPU usage percentage
+			# TYPE vergeos_node_cpu_user gauge
+			vergeos_node_cpu_user{cluster="cluster1",node_name="node1",system_name="testcloud"} 20
+			vergeos_node_cpu_user{cluster="cluster1",node_name="node2",system_name="testcloud"} 10
+			# HELP vergeos_node_cpu_system System CPU usage percentage
+			# TYPE vergeos_node_cpu_system gauge
+			vergeos_node_cpu_system{cluster="cluster1",node_name="node1",system_name="testcloud"} 15
+			vergeos_node_cpu_system{cluster="cluster1",node_name="node2",system_name="testcloud"} 15
+			# HELP vergeos_node_cpu_iowait IO Wait CPU usage percentage
+			# TYPE vergeos_node_cpu_iowait gauge
+			vergeos_node_cpu_iowait{cluster="cluster1",node_name="node1",system_name="testcloud"} 10
+			vergeos_node_cpu_iowait{cluster="cluster1",node_name="node2",system_name="testcloud"} 5
+		`
+		if err := testutil.CollectAndCompare(
+			collector,
+			strings.NewReader(expected),
+			"vergeos_node_cpu_total",
+			"vergeos_node_cpu_user",
+			"vergeos_node_cpu_system",
+			"vergeos_node_cpu_iowait",
+		); err != nil {
 			t.Errorf("Unexpected metric values: %v", err)
 		}
 	})

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -27,7 +27,7 @@ func TestVMCollector(t *testing.T) {
 	}
 
 	allMachineStats := []MachineStatsMock{
-		{Key: 1, Machine: 101, TotalCPU: 75, UserCPU: 50, SystemCPU: 20, IOWaitCPU: 5},
+		{Key: 1, Machine: 101, TotalCPU: 75},
 	}
 
 	allMachineStatuses := []MachineStatusMock{
@@ -111,9 +111,6 @@ func TestVMCollector(t *testing.T) {
 	// Verify all expected metrics exist
 	expectedMetrics := map[string]bool{
 		"vergeos_vm_cpu_total":              false,
-		"vergeos_vm_cpu_user":               false,
-		"vergeos_vm_cpu_system":             false,
-		"vergeos_vm_cpu_iowait":             false,
 		"vergeos_vm_running":                false,
 		"vergeos_vm_enabled":                false,
 		"vergeos_vm_cpu_cores":              false,
@@ -141,6 +138,17 @@ func TestVMCollector(t *testing.T) {
 	for metric, found := range expectedMetrics {
 		if !found {
 			t.Errorf("Expected metric %s not found", metric)
+		}
+	}
+
+	removedMetrics := map[string]bool{
+		"vergeos_vm_cpu_user":   true,
+		"vergeos_vm_cpu_system": true,
+		"vergeos_vm_cpu_iowait": true,
+	}
+	for _, mf := range metrics {
+		if removedMetrics[mf.GetName()] {
+			t.Errorf("Removed metric %s is still exposed", mf.GetName())
 		}
 	}
 
@@ -319,7 +327,7 @@ func TestVMCollector_SnapshotFiltering(t *testing.T) {
 
 		case strings.Contains(r.URL.Path, "/machine_stats"):
 			WriteJSONResponse(w, []MachineStatsMock{
-				{Key: 1, Machine: 101, TotalCPU: 30, UserCPU: 20, SystemCPU: 8, IOWaitCPU: 2},
+				{Key: 1, Machine: 101, TotalCPU: 30},
 			})
 			return true
 
@@ -389,7 +397,7 @@ func TestVMCollector_StaleMetrics(t *testing.T) {
 			var stats []MachineStatsMock
 			for i := 1; i <= vmCount; i++ {
 				stats = append(stats, MachineStatsMock{
-					Key: i, Machine: 100 + i, TotalCPU: 50, UserCPU: 30, SystemCPU: 15, IOWaitCPU: 5,
+					Key: i, Machine: 100 + i, TotalCPU: 50,
 				})
 			}
 			WriteJSONResponse(w, stats)


### PR DESCRIPTION
## Summary

Promote the current `dev` branch to `main` for the `v2.1.1` patch release.

## Changes

- add API key authentication as an alternative to username/password authentication (#54)
- remove misleading always-zero detailed VM CPU metrics (#55)
- expose total, user, system, and I/O-wait CPU metrics for physical nodes (#55)
- update focused tests and metric documentation

## Validation

- `go test ./...`
- `go vet ./...`
- `gofmt -l $(git ls-files '*.go')`
- `go test -tags=integration ./tests -count=1 -v`
- validated all collectors against the live VergeOS system configured in `.env`
- confirmed the physical-node CPU metrics match live `/machine_stats` values and the removed VM metric families are absent

After this PR is merged, tag its merge commit as `v2.1.1` to trigger the existing GoReleaser workflow.

Closes #47
