### PR TITLE
feat: add Virtual Networks dashboard row for VNet metrics

### DIFF
--- a/examples/grafana-dashboard.json
+++ b/examples/grafana-dashboard.json
@@ -2426,6 +2426,594 @@
         "x": 0,
         "y": 67
       },
+      "id": 69,
+      "panels": [],
+      "title": "Virtual Networks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 68
+      },
+      "id": 70,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, rate(vergeos_vnet_tx_bytes_total{system_name=~\"$system\", vnet_name=~\"$vnet\"}[5m]))",
+          "legendFormat": "{{vnet_name}} TX",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, rate(vergeos_vnet_rx_bytes_total{system_name=~\"$system\", vnet_name=~\"$vnet\"}[5m]))",
+          "legendFormat": "{{vnet_name}} RX",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "VNet Router Traffic",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "pps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 68
+      },
+      "id": 71,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, rate(vergeos_vnet_tx_packets_total{system_name=~\"$system\", vnet_name=~\"$vnet\"}[5m]))",
+          "legendFormat": "{{vnet_name}} TX",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(20, rate(vergeos_vnet_rx_packets_total{system_name=~\"$system\", vnet_name=~\"$vnet\"}[5m]))",
+          "legendFormat": "{{vnet_name}} RX",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "VNet Router Packets",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent",
+          "min": 0,
+          "max": 100
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "id": 72,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_quality{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} quality",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_dropped_pct{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} dropped %",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Gateway Quality & Packet Loss",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 73,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_latency_usec_avg{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} avg",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_latency_usec_peak{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} peak",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Gateway Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 84
+      },
+      "id": 74,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_duplicates{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} duplicates",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_truncated{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} truncated",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_dropped{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} dropped",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_bad_checksums{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} bad checksums",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "vergeos_vnet_monitor_bad_data{system_name=~\"$system\", vnet_name=~\"$vnet\"}",
+          "legendFormat": "{{vnet_name}} bad data",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Gateway Monitor Errors",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 92
+      },
       "id": 53,
       "panels": [],
       "title": "Tenants",
@@ -2458,7 +3046,7 @@
         "h": 6,
         "w": 3,
         "x": 0,
-        "y": 68
+        "y": 93
       },
       "id": 54,
       "options": {
@@ -2521,7 +3109,7 @@
         "h": 6,
         "w": 3,
         "x": 3,
-        "y": 68
+        "y": 93
       },
       "id": 55,
       "options": {
@@ -2593,7 +3181,7 @@
         "h": 6,
         "w": 9,
         "x": 6,
-        "y": 68
+        "y": 93
       },
       "id": 56,
       "options": {
@@ -2673,7 +3261,7 @@
         "h": 6,
         "w": 9,
         "x": 15,
-        "y": 68
+        "y": 93
       },
       "id": 57,
       "options": {
@@ -2781,7 +3369,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 74
+        "y": 99
       },
       "id": 58,
       "options": {
@@ -2890,7 +3478,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 74
+        "y": 99
       },
       "id": 59,
       "options": {
@@ -2929,7 +3517,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 88
+        "y": 113
       },
       "id": 60,
       "panels": [],
@@ -3051,7 +3639,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 89
+        "y": 114
       },
       "id": 61,
       "options": {
@@ -3250,7 +3838,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 99
+        "y": 124
       },
       "id": 62,
       "options": {
@@ -3347,7 +3935,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 134
       },
       "id": 64,
       "options": {
@@ -3456,7 +4044,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 119
+        "y": 144
       },
       "id": 67,
       "options": {
@@ -3568,7 +4156,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 129
+        "y": 154
       },
       "id": 68,
       "options": {
@@ -3703,6 +4291,23 @@
         "query": {
           "qryType": 5,
           "query": "label_values(vergeos_vm_running{system_name=~\"$system\"}, vm_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "label_values(vergeos_vnet_enabled{system_name=~\"$system\"}, vnet_name)",
+        "includeAll": true,
+        "label": "VNet",
+        "multi": true,
+        "name": "vnet",
+        "options": [],
+        "query": {
+          "qryType": 5,
+          "query": "label_values(vergeos_vnet_enabled{system_name=~\"$system\"}, vnet_name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
## Summary

- add a "Virtual Networks" row to the example Grafana dashboard with five timeseries panels: router traffic (Bps), router packets (pps), gateway quality & packet loss (%), gateway latency (µs), and gateway monitor error counters
- add a `vnet` template variable (`label_values(vergeos_vnet_enabled{system_name=~"$system"}, vnet_name)`, multi-select) matching the existing `vm`/`tenant` variable pattern
- wrap the traffic/packet queries in `topk(20, ...)` to bound series count and payload size on systems with many VNets

## Impact

- Panels use the v2.1.1 VNet metrics only; no exporter or compose changes needed
- Counter metrics (`vergeos_vnet_{tx,rx}_{bytes,packets}_total`) use `rate(...[5m])`; all `vergeos_vnet_monitor_*` gauges are graphed raw since they are latest-sample values
- Gateway panels show "No data" on systems without gateway monitoring enabled, matching existing dashboard conventions
- Existing panels are unchanged apart from `gridPos.y` shifting down to make room for the new row (placed between Network and Tenants)

## Validation

- `go test ./...`
- `python3 -m json.tool examples/grafana-dashboard.json` (valid JSON)
- structural validation script asserting panel ids/units/queries, no duplicate ids, and exact gridPos shift of all pre-existing panels
- provisioned the updated dashboard into a live Grafana + Prometheus + exporter v2.1.1 stack scraping a VergeOS system with 18 VNets and one gateway-monitored network: Grafana loaded all 51 panels; traffic/packet queries returned 18 series; each gateway monitor query returned exactly the one monitored network; Grafana `/api/ds/query` returned 18 frames for the traffic panel
- removed the test copy from the stack after verification

Closes #57