### PR TITLE
docs: update README Grafana dashboard section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,13 @@ See [metrics.md](metrics.md) for a complete list of exported metrics.
 
 A pre-configured Grafana dashboard is included in the `examples/grafana-dashboard.json` file. This dashboard provides a comprehensive visualization of VergeOS metrics including:
 
-- VSAN tier performance and health metrics
-- Cluster resource utilization and status
+- System overview (version, node/VM/tenant counts, CPU and RAM capacity)
+- VSAN tier capacity, usage, and health, plus per-drive details
 - Node health and performance indicators
-- Storage metrics and drive status
+- Physical network (NIC) status and traffic
+- Virtual network router traffic and gateway monitoring
+- Tenant resource and storage usage
+- Per-VM CPU, network, and disk activity
 
 To import the dashboard:
 


### PR DESCRIPTION
## Summary

- update the bullet list under "## Grafana Dashboard" in `README.md` to describe the dashboard's actual seven rows (System Overview, VSAN, Drive Details, Network, Virtual Networks, Tenants, Virtual Machines)
- the previous list predated the Network, Tenants, Virtual Machines, and Virtual Networks rows

## Validation

- docs-only change; no code, tests, or dashboard modifications
- verified each bullet corresponds to a row/panel group present in `examples/grafana-dashboard.json` (51 panels across 7 rows)

Fixes #60