### PR TITLE
promote dev: README Grafana dashboard docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,13 @@ See [metrics.md](metrics.md) for a complete list of exported metrics.
 
 A pre-configured Grafana dashboard is included in the `examples/grafana-dashboard.json` file. This dashboard provides a comprehensive visualization of VergeOS metrics including:
 
-- VSAN tier performance and health metrics
-- Cluster resource utilization and status
+- System overview (version, node/VM/tenant counts, CPU and RAM capacity)
+- VSAN tier capacity, usage, and health, plus per-drive details
 - Node health and performance indicators
-- Storage metrics and drive status
+- Physical network (NIC) status and traffic
+- Virtual network router traffic and gateway monitoring
+- Tenant resource and storage usage
+- Per-VM CPU, network, and disk activity
 
 To import the dashboard:
 


### PR DESCRIPTION
## Summary

Promote the current `dev` branch to `main` to publish the README documentation fix.

## Changes

- update the bullet list under "## Grafana Dashboard" in `README.md` to describe the dashboard's actual seven rows — System Overview, VSAN, Drive Details, Network, Virtual Networks, Tenants, Virtual Machines (#61)
- the previous list predated the Network, Tenants, Virtual Machines, and Virtual Networks rows

## Validation

- docs-only change; no code, tests, or dashboard modifications
- each bullet corresponds to a row/panel group present in `examples/grafana-dashboard.json`

No exporter code changes are included, so no release tag is needed; binaries remain v2.1.1.

Closes #60