### PR TITLE
feat: export per-VM RAM usage for v2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The exporter supports both standard Prometheus text format and [OpenMetrics](htt
 
 Prebuilt binaries for Linux, Windows, and macOS (both amd64 and arm64) are available on the [Releases](https://github.com/verge-io/vergeos-exporter/releases) page.
 
-Note that the version number is included in the filename (e.g., vergeos-exporter_2.1.0_Darwin_x86_64.tar.gz), so ensure you download the correct version for your system.
+Note that the version number is included in the filename (e.g., vergeos-exporter_2.1.2_Darwin_x86_64.tar.gz), so ensure you download the correct version for your system.
 
 1. Download the appropriate binary for your system
 2. Extract the archive:
@@ -68,7 +68,7 @@ docker run --rm -p 9888:9888 \
 
 Available tags:
 - `ghcr.io/verge-io/vergeos-exporter:latest` — most recent release
-- `ghcr.io/verge-io/vergeos-exporter:2.1.0` — specific version (no `v` prefix)
+- `ghcr.io/verge-io/vergeos-exporter:2.1.2` — specific version (no `v` prefix)
 
 See `examples/docker-compose/` for a complete monitoring stack with Prometheus and Grafana.
 

--- a/collectors/vm.go
+++ b/collectors/vm.go
@@ -27,6 +27,9 @@ type VMCollector struct {
 	// CPU metrics
 	vmCPUTotal *prometheus.Desc
 
+	// Memory metrics
+	vmRAMUsedBytes *prometheus.Desc
+
 	// State metrics
 	vmRunning *prometheus.Desc
 	vmEnabled *prometheus.Desc
@@ -65,6 +68,12 @@ func NewVMCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VMColl
 		vmCPUTotal: prometheus.NewDesc(
 			"vergeos_vm_cpu_total",
 			"Total CPU usage percentage",
+			vmLabels,
+			nil,
+		),
+		vmRAMUsedBytes: prometheus.NewDesc(
+			"vergeos_vm_ram_used_bytes",
+			"Physical host RAM used by the VM in bytes",
 			vmLabels,
 			nil,
 		),
@@ -170,6 +179,7 @@ func NewVMCollector(client *vergeos.Client, scrapeTimeout time.Duration) *VMColl
 // Describe implements prometheus.Collector
 func (vc *VMCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- vc.vmCPUTotal
+	ch <- vc.vmRAMUsedBytes
 	ch <- vc.vmRunning
 	ch <- vc.vmEnabled
 	ch <- vc.vmCPUCores
@@ -273,13 +283,15 @@ func (vc *VMCollector) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(vc.vmCPUCores, prometheus.GaugeValue, float64(vm.CPUCores), labels...)
 		ch <- prometheus.MustNewConstMetric(vc.vmRAMBytes, prometheus.GaugeValue, float64(vm.RAM)*1048576, labels...)
 
-		// CPU stats (0 if powered off or no stats available)
-		var totalCPU float64
+		// Runtime stats (0 if powered off or no stats available)
+		var totalCPU, ramUsedBytes float64
 		if stats, ok := statsMap[vm.Machine]; ok {
 			totalCPU = float64(stats.TotalCPU)
+			ramUsedBytes = float64(stats.RAMUsed) * 1048576
 		}
 
 		ch <- prometheus.MustNewConstMetric(vc.vmCPUTotal, prometheus.GaugeValue, totalCPU, labels...)
+		ch <- prometheus.MustNewConstMetric(vc.vmRAMUsedBytes, prometheus.GaugeValue, ramUsedBytes, labels...)
 
 		// NIC metrics (only for VMs with NICs)
 		if nics, ok := nicMap[vm.Machine]; ok {

--- a/metrics.md
+++ b/metrics.md
@@ -191,6 +191,12 @@ All VM metrics include labels: `system_name`, `cluster`, `node`, `vm_name`, `vm_
 - **Total CPU Usage**: `vergeos_vm_cpu_total` (Gauge, percentage 0-100)
 
 Powered-off VMs report 0 CPU usage.
+VergeOS does not populate the per-category CPU fields for VM machines, so user, system, and I/O-wait CPU metrics are not exposed.
+
+### VM Memory Metrics
+- **RAM Used**: `vergeos_vm_ram_used_bytes` (Gauge, physical host RAM used by the VM in bytes)
+
+`ram_used` comes from the host's `machine_stats` record in MB and is converted to bytes. It is host-resident memory usage, not guest-reported usage, and does not depend on the guest agent. Powered-off VMs report 0.
 
 ### VM NIC Metrics
 Additional label: `nic_name`. Only emitted for VMs with NIC stats available.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -271,6 +271,16 @@ func TestIntegrationVMCollector(t *testing.T) {
 		}
 	})
 
+	t.Run("vm_ram_used_bytes", func(t *testing.T) {
+		found := filterMetrics(metrics, "vergeos_vm_ram_used_bytes")
+		if len(found) == 0 {
+			t.Fatal("Expected at least one vergeos_vm_ram_used_bytes metric")
+		}
+		for _, m := range found {
+			assertHasLabels(t, m, "system_name", "cluster", "node", "vm_name", "vm_id")
+		}
+	})
+
 	t.Run("vm_nic_tx_bytes", func(t *testing.T) {
 		found := filterMetrics(metrics, "vergeos_vm_nic_tx_bytes_total")
 		t.Logf("Found %d VM NIC TX bytes metrics", len(found))

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -27,7 +27,7 @@ func TestVMCollector(t *testing.T) {
 	}
 
 	allMachineStats := []MachineStatsMock{
-		{Key: 1, Machine: 101, TotalCPU: 75},
+		{Key: 1, Machine: 101, TotalCPU: 75, RAMUsed: 2048},
 	}
 
 	allMachineStatuses := []MachineStatusMock{
@@ -111,6 +111,7 @@ func TestVMCollector(t *testing.T) {
 	// Verify all expected metrics exist
 	expectedMetrics := map[string]bool{
 		"vergeos_vm_cpu_total":              false,
+		"vergeos_vm_ram_used_bytes":         false,
 		"vergeos_vm_running":                false,
 		"vergeos_vm_enabled":                false,
 		"vergeos_vm_cpu_cores":              false,
@@ -208,6 +209,18 @@ func TestVMCollector(t *testing.T) {
 			vergeos_vm_ram_bytes{cluster="compute-cluster",node="",system_name="testcloud",vm_id="2",vm_name="db-server"} 1.7179869184e+10
 		`
 		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vm_ram_bytes"); err != nil {
+			t.Errorf("Unexpected metric values: %v", err)
+		}
+	})
+
+	t.Run("ram_used_bytes", func(t *testing.T) {
+		expected := `
+			# HELP vergeos_vm_ram_used_bytes Physical host RAM used by the VM in bytes
+			# TYPE vergeos_vm_ram_used_bytes gauge
+			vergeos_vm_ram_used_bytes{cluster="compute-cluster",node="node1",system_name="testcloud",vm_id="1",vm_name="web-server"} 2.147483648e+09
+			vergeos_vm_ram_used_bytes{cluster="compute-cluster",node="",system_name="testcloud",vm_id="2",vm_name="db-server"} 0
+		`
+		if err := testutil.CollectAndCompare(collector, strings.NewReader(expected), "vergeos_vm_ram_used_bytes"); err != nil {
 			t.Errorf("Unexpected metric values: %v", err)
 		}
 	})


### PR DESCRIPTION
## Summary

- export `vergeos_vm_ram_used_bytes` from the existing batched `machine_stats.ram_used` response
- convert the VergeOS MB value to bytes and preserve zero values for powered-off VMs
- document that this is host-resident memory and does not depend on the guest agent
- update release examples to `2.1.2`

## Scope correction

`iowait_cpu` and `ram_pct` remain unexported because VergeOS 26.1.7 does not populate them for VM machines. Across 1,007 recent VM samples, 304 had nonzero `total_cpu`, none had nonzero `iowait_cpu`, and `ram_pct` remained zero while `ram_used` was populated. Exporting those fields would recreate misleading always-zero series previously removed by #47.

## Validation

- `go test ./...`
- `go vet ./...`
- `goreleaser build --snapshot --clean`
- `go test -tags=integration ./tests -run TestIntegrationVMCollector -count=1 -v`
- live API verification against VergeOS 26.1.7

Closes #63